### PR TITLE
Implement parallel data iterator using FLoops.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,8 @@ version = "0.2.1"
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
+FoldsThreads = "9c68100b-dfe1-47cf-94c8-95104e173443"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ShowCases = "605ecd9f-84a6-4c9e-81e2-4798472b76a3"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLUtils"
 uuid = "f1d291b0-491e-4a28-83b9-f70985020b54"
 authors = ["Carlo Lucibello <carlo.lucibello@gmail.com> and contributors"]
-version = "0.1.4"
+version = "0.2.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -3,32 +3,38 @@ module MLUtils
 using Random
 using Statistics
 using ShowCases: ShowLimit
+using FLoops: @floop
+using FLoops.Transducers: Executor
+using FoldsThreads: TaskPoolEx
 import StatsBase: sample
 using Base: @propagate_inbounds
 using Random: AbstractRNG, shuffle!, GLOBAL_RNG
 import ChainRulesCore: rrule
-using ChainRulesCore: @non_differentiable, unthunk, AbstractZero, 
+using ChainRulesCore: @non_differentiable, unthunk, AbstractZero,
                       NoTangent, ZeroTangent, ProjectTo
 
 
 include("observation.jl")
-export numobs, 
-       getobs, 
+export numobs,
+       getobs,
        getobs!
 
 include("obstransform.jl")
-export mapobs, 
-       filterobs, 
+export mapobs,
+       filterobs,
        groupobs,
-       joinobs,
-       shuffleobs
+       joinobs
 
 include("batchview.jl")
 export batchsize,
        BatchView
 
-include("eachobs.jl")
-export eachobs
+include("dataiterator.jl")
+export eachobs,
+       eachbatch
+
+include("parallel.jl")
+export eachobsparallel
 
 include("dataloader.jl")
 export DataLoader
@@ -45,7 +51,8 @@ include("randobs.jl")
 export randobs
 
 include("resample.jl")
-export oversample,
+export labelmap,
+       oversample,
        undersample
 
 include("splitobs.jl")
@@ -57,7 +64,7 @@ export batch,
        chunk,
        flatten,
        group_counts,
-       group_indices, 
+       group_indices,
        normalise,
        stack,
        unbatch,
@@ -67,7 +74,7 @@ export batch,
 
 include("Datasets/Datasets.jl")
 using .Datasets
-export Datasets, 
+export Datasets,
        load_iris
 
 include("deprecations.jl")

--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -29,9 +29,8 @@ include("batchview.jl")
 export batchsize,
        BatchView
 
-include("dataiterator.jl")
-export eachobs,
-       eachbatch
+include("eachobs.jl")
+export eachobs
 
 include("parallel.jl")
 export eachobsparallel

--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -4,7 +4,7 @@ using Random
 using Statistics
 using ShowCases: ShowLimit
 using FLoops: @floop
-using FLoops.Transducers: Executor
+using FLoops.Transducers: Executor, ThreadedEx
 using FoldsThreads: TaskPoolEx
 import StatsBase: sample
 using Base: @propagate_inbounds

--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -23,7 +23,8 @@ include("obstransform.jl")
 export mapobs,
        filterobs,
        groupobs,
-       joinobs
+       joinobs,
+       shuffleobs
 
 include("batchview.jl")
 export batchsize,

--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -34,7 +34,6 @@ include("eachobs.jl")
 export eachobs
 
 include("parallel.jl")
-export eachobsparallel
 
 include("dataloader.jl")
 export DataLoader
@@ -51,8 +50,7 @@ include("randobs.jl")
 export randobs
 
 include("resample.jl")
-export labelmap,
-       oversample,
+export oversample,
        undersample
 
 include("splitobs.jl")

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -27,7 +27,7 @@ to the number of physical CPU cores.
 """
 function eachobsparallel(
         data;
-        executor::Executor = _default_executor()
+        executor::Executor = _default_executor(),
         buffer = false,
         channelsize = Threads.nthreads())
     if buffer

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -1,0 +1,62 @@
+"""
+    eachobsparallel(data)
+
+Construct a data iterator over observations in container `data`.
+It uses available threads as workers to load observations in
+parallel, leading to large speedups when threads are available.
+"""
+function eachobsparallel(
+        data,
+        executor::Executor;
+        buffersize = Threads.nthreads())
+    return Loader(executor, buffersize, 1:numobs(data)) do i
+        getobs(data, i)
+    end
+end
+
+# The default executor behaves similarly to DataLoaders.jl and allows
+# loading data in the background
+function eachobsparallel(data; background = true, kwargs...)
+    return eachobsparallel(data, TaskPoolEx(background=background); kwargs...)
+end
+
+
+mutable struct Loader
+    f::Any
+    executor::Any
+    channelsize::Any
+    argiter::Any
+end
+
+Base.length(loader::Loader) = length(loader.argiter)
+
+struct LoaderState
+    spawnertask::Any
+    channel::Any
+    remaining::Any
+end
+
+function Base.iterate(loader::Loader)
+    ch = Channel(loader.channelsize)
+    task = @async begin
+
+        @floop loader.executor for arg in loader.argiter
+            try
+                result = loader.f(arg)
+                put!(ch, result)
+            catch e
+                close(ch, e)
+                rethrow()
+            end
+        end
+        close(ch)
+    end
+
+    return Base.iterate(loader, LoaderState(task, ch, length(loader.argiter)))
+end
+
+function Base.iterate(::Loader, state::LoaderState)
+    state.remaining == 0 && return nothing
+    result = take!(state.channel)
+    return result, LoaderState(state.spawnertask, state.channel, state.remaining - 1)
+end

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -1,6 +1,6 @@
 """
     eachobsparallel(data)
-    eachobsparallel(data[, executor; buffersize])
+    eachobsparallel(data; buffer, executor; channelsize)
 
 Construct a data iterator over observations in container `data`.
 It uses available threads as workers to load observations in
@@ -15,23 +15,57 @@ to the number of physical CPU cores.
 ## Arguments
 
 - `data`: a data container that implements `getindex/getobs` and `length/numobs`
+- `buffer = false`: whether to use inplace data loading with `getobs!`. Only use
+    this if you need the additional performance and `getobs!` is implemented for
+    `data`. Setting `buffer = true` means that when using the iterator, an
+    observation is only valid for the current loop iteration.
 - `executor = Folds.ThreadedEx()`: task scheduler
-
     You may specify a different task scheduler which can
     be any `Folds.Executor`.
-- `buffersize = Threads.nthreads()`: the number of observations that are prefetched.
-
-    Increasing `buffersize` can lead to speedups when per-observation processing
+- `channelsize = Threads.nthreads()`: the number of observations that are prefetched.
+    Increasing `channelsize` can lead to speedups when per-observation processing
     time is irregular but will cause higher memory usage.
 """
 function eachobsparallel(
         data,
         executor::Executor = _default_executor();
-        buffersize = Threads.nthreads())
-    return Loader(executor, buffersize, 1:numobs(data)) do i
-        getobs(data, i)
+        buffer = false,
+        channelsize = Threads.nthreads())
+    if buffer
+        return _eachobsparallel_buffered(data, executor; channelsize)
+    else
+        return _eachobsparallel_unbuffered(data, executor; channelsize)
     end
 end
+
+
+function _eachobsparallel_buffered(data, executor; channelsize=Threads.nthreads())
+    # Prepare initial buffers
+    buf = getobs(data, 1)
+    buffers = [buf]
+    foreach(_ -> push!(buffers, deepcopy(buf)), 1:channelsize)
+
+    # This ensures the `Loader` will take from the `RingBuffer`s result
+    # channel, and that a new results channel is created on repeated
+    # iteration. (Since `Loader`) closes the previous at the end of
+    # each iteration.
+    setup_channel(sz) = RingBuffer(buffers)
+
+    return Loader(1:numobs(data); executor, channelsize, setup_channel) do ringbuffer, i
+        # Internally, `RingBuffer` will `put!` the result in the results channel
+        put!(ringbuffer) do buf
+            getobs!(buf, data, i)
+        end
+    end
+end
+
+function _eachobsparallel_unbuffered(data, executor; channelsize=Threads.nthreads())
+    return Loader(1:numobs(data); executor, channelsize) do ch, i
+        obs = getobs(data, i)
+        put!(ch, obs)
+    end
+end
+
 
 # Unlike DataLoaders.jl, this currently does not use task pools
 # since  `ThreadedEx` has shown to be more performant. This may
@@ -40,11 +74,36 @@ end
 _default_executor() = ThreadedEx(basesize=1)
 
 
+# ## Internals
+
+# The `Loader` handles the asynchronous iteration and fills
+# a result channel.
+
+
+"""
+    Loader(f, args; executor, channelsize, setup_channel)
+
+Create a threaded iterator that iterates over `(f(arg) for arg in args)`
+using threads that prefill a channel of length `channelsize`.
+
+Note: results may not be returned in the correct order, depending on
+`executor`.
+"""
 mutable struct Loader
     f::Any
+    argiter::Any
     executor::Any
     channelsize::Any
-    argiter::Any
+    setup_channel::Any
+end
+
+function Loader(
+        f,
+        argiter;
+        executor=_default_executor(),
+        channelsize=Threads.nthreads(),
+        setup_channel = sz -> Channel(sz))
+    Loader(f, argiter, executor, channelsize, setup_channel)
 end
 
 Base.length(loader::Loader) = length(loader.argiter)
@@ -56,13 +115,11 @@ struct LoaderState
 end
 
 function Base.iterate(loader::Loader)
-    ch = Channel(loader.channelsize)
+    ch = loader.setup_channel(loader.channelsize)
     task = @async begin
-
         @floop loader.executor for arg in loader.argiter
             try
-                result = loader.f(arg)
-                @async put!(ch, result)
+                loader.f(ch, arg)
             catch e
                 close(ch, e)
                 rethrow()
@@ -81,4 +138,91 @@ function Base.iterate(::Loader, state::LoaderState)
         result = take!(state.channel)
         return result, LoaderState(state.spawnertask, state.channel, state.remaining - 1)
     end
+end
+
+
+# The `RingBuffer` ensures that the same buffers are reused
+# and the loading works asynchronously.
+
+"""
+    RingBuffer(size, buffer)
+    RingBuffer(buffers)
+
+A `Channel`-like data structure that rotates through
+`size` buffers. You can either pass in a vector of `buffers`, or
+a single `buffer` that is copied `size` times.
+
+`put!`s work by mutating one of the buffers:
+
+```
+put!(ringbuffer) do buf
+    rand!(buf)
+end
+```
+
+The result can then be `take!`n:
+
+```
+res = take!(ringbuffer)
+```
+
+!!! warning "Invalidation"
+
+    Only one result is valid at a time! On the next `take!`, the previous
+    result will be reused as a buffer and be mutated by a `put!`
+"""
+mutable struct RingBuffer{T}
+    buffers::Channel{T}
+    results::Channel{T}
+    current::T
+end
+
+function RingBuffer(bufs::Vector{T}) where T
+    size = length(bufs) - 1
+    ch_buffers = Channel{T}(size + 1)
+    ch_results = Channel{T}(size)
+    foreach(bufs[begin+1:end]) do buf
+        put!(ch_buffers, buf)
+    end
+
+    return RingBuffer{T}(ch_buffers, ch_results, bufs[begin])
+end
+
+
+function Base.take!(ringbuffer::RingBuffer)
+    put!(ringbuffer.buffers, ringbuffer.current)
+    ringbuffer.current = take!(ringbuffer.results)
+    return ringbuffer.current
+end
+
+
+"""
+    put!(f!, ringbuffer::RingBuffer)
+
+Apply f! to a buffer in `ringbuffer` and put into the results
+channel.
+
+```julia
+x = rand(10, 10)
+ringbuffer = RingBuffer(1, x)
+put!(ringbuffer) do buf
+    @test x == buf
+    copy!(buf, rand(10, 10))
+end
+x_ = take!(ringbuffer)
+@test !(x ≈ x_)
+
+```
+"""
+function Base.put!(f!, ringbuffer::RingBuffer)
+    buf = take!(ringbuffer.buffers)
+    buf_ = f!(buf)
+    put!(ringbuffer.results, buf_)
+    return buf_
+end
+
+
+function Base.close(ringbuffer::RingBuffer, args...)
+    close(ringbuffer.results, args...)
+    close(ringbuffer.buffers, args...)
 end

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -89,12 +89,12 @@ using threads that prefill a channel of length `channelsize`.
 Note: results may not be returned in the correct order, depending on
 `executor`.
 """
-mutable struct Loader
-    f::Any
-    argiter::Any
-    executor::Any
-    channelsize::Any
-    setup_channel::Any
+struct Loader
+    f
+    argiter::AbstractVector
+    executor::Executor
+    channelsize::Int
+    setup_channel
 end
 
 function Loader(

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -1,6 +1,5 @@
 """
-    eachobsparallel(data)
-    eachobsparallel(data; buffer, executor; channelsize)
+    eachobsparallel(data; buffer, executor, channelsize)
 
 Construct a data iterator over observations in container `data`.
 It uses available threads as workers to load observations in
@@ -27,8 +26,8 @@ to the number of physical CPU cores.
     time is irregular but will cause higher memory usage.
 """
 function eachobsparallel(
-        data,
-        executor::Executor = _default_executor();
+        data;
+        executor::Executor = _default_executor()
         buffer = false,
         channelsize = Threads.nthreads())
     if buffer

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -1,0 +1,56 @@
+@testset "eachobsparallel" begin
+
+    @testset "Iteration" begin
+        iter = eachobsparallel(collect(1:10))
+        @test_nowarn for i in iter end
+        X_ = collect(iter)
+        @test all(x ∈ 1:10 for x in X_)
+        @test length(unique(X_)) == 10
+    end
+
+    @testset "With `TaskPoolEx`" begin
+        iter = eachobsparallel(collect(1:10), TaskPoolEx())
+        @test_nowarn for i in iter end
+        X_ = collect(iter)
+        @test all(x ∈ 1:10 for x in X_)
+        @test length(unique(X_)) == 10
+    end
+end
+
+
+@testset "RingBuffer" begin
+    @testset "fills correctly" begin
+        x = rand(10, 10)
+        ringbuffer = RingBuffer([x, deepcopy(x), deepcopy(x)])
+        @async begin
+            for i ∈ 1:100
+                put!(ringbuffer) do buf
+                    rand!(buf)
+                end
+            end
+        end
+        @test_nowarn for _ ∈ 1:100
+            take!(ringbuffer)
+        end
+    end
+
+    @testset "does mutate" begin
+        x = rand(10, 10)
+        ringbuffer = RingBuffer([x, deepcopy(x), deepcopy(x)])
+        put!(ringbuffer) do buf
+            @test x ≈ buf
+            copy!(buf, rand(10, 10))
+            buf
+        end
+        x_ = take!(ringbuffer)
+        @test !(x ≈ x_)
+    end
+end
+
+@testset "`eachobsparallel(buffer = true)`" begin
+    iter = eachobsparallel(collect(1:10), buffer=true)
+    @test_nowarn for i in iter end
+    X_ = collect(iter)
+    @test all(x ∈ 1:10 for x in X_)
+    @test length(unique(X_)) == 10
+end

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -9,7 +9,7 @@
     end
 
     @testset "With `TaskPoolEx`" begin
-        iter = eachobsparallel(collect(1:10), TaskPoolEx())
+        iter = eachobsparallel(collect(1:10); executor = TaskPoolEx())
         @test_nowarn for i in iter end
         X_ = collect(iter)
         @test all(x ∈ 1:10 for x in X_)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using MLUtils
 using MLUtils.Datasets
-using MLUtils: RingBuffer
+using MLUtils: RingBuffer, eachobsparallel
 using SparseArrays
 using Random, Statistics
 using Test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,12 @@
 using MLUtils
 using MLUtils.Datasets
+using MLUtils: RingBuffer
 using SparseArrays
 using Random, Statistics
 using Test
+using FoldsThreads: TaskPoolEx
 using ChainRulesTestUtils: test_rrule
-using Zygote: ZygoteRuleConfig 
+using Zygote: ZygoteRuleConfig
 using ChainRulesCore: rrule_via_ad
 
 showcompact(io, x) = show(IOContext(io, :compact => true), x)
@@ -57,6 +59,7 @@ include("test_utils.jl")
 @testset "resample" begin; include("resample.jl"); end
 @testset "splitobs" begin; include("splitobs.jl"); end
 @testset "utils" begin; include("utils.jl"); end
+@testset "eachobsparallel" begin; include("parallel.jl"); end
 
 @testset "Datasets/datasets" begin; include("Datasets/datasets.jl"); end
 @testset "Datasets/generators" begin; include("Datasets/generators.jl"); end


### PR DESCRIPTION
This is a ~~proof-of-concept for a~~ parallel data iterator matching the behavior of DataLoaders.jl, but implemented using FLoops.jl and [FoldsThreads.jl](https://github.com/JuliaFolds/FoldsThreads.jl). Closes #30 

Why use FLoops.jl for this and not just copy from DataLoaders.jl?

- The parallelism code in DataLoaders.jl is quite opaque (I would know) and not exactly minimal, to the point where I've been very hesitant to make changes.
- DataLoaders.jl has had a longstanding issue with brittle interrupt handling where, sometimes, the session would hang and need to be restarted. AFAICT this issue does not exist with this PR's implementation. 
- FoldsThreads.jl provides many different executors, allowing to adapt to the specific workload
- Where as DataLoaders.jl would use either N or N-1 threads, FLoops.jl allows using fewer workers too [using basesize](https://juliafolds.github.io/data-parallelism/howto/faq/#set-nthreads-at-run-time)

Current scope:
- buffered version is not implemented yet, but can easily reuse this `Loader`; just need to port DataLoaders.jl's `RingBuffer`
- API not final, see #30 for discussion on API

## Benchmarks vs. DataLoaders.jl

I have done some throughput tests on synthetic, uniform workloads and this PR seems to perform pretty well.
```julia
import LearnBase
import MLUtils
using Transducers: ThreadedEx

struct TimeDataset
    n::Any
    t::Any
end

LearnBase.getobs(data::TimeDataset, idx) = (sleep(data.t); return idx)
LearnBase.nobs(data::TimeDataset) = data.n
MLUtils.getobs(data::TimeDataset, idx) = (sleep(data.t); return idx)
MLUtils.numobs(data::TimeDataset) = data.n

data = TimeDataset(100, 0.1)
@elapsed for _ in MLUtils.eachobsparallel(data, ThreadedEx()) end
@elapsed for _ in DataLoaders.eachobsparallel(data) end

data = TimeDataset(10000, 0.001)
@elapsed for _ in MLUtils.eachobsparallel(data, ThreadedEx()) end
@elapsed for _ in DataLoaders.eachobsparallel(data) end

data = TimeDataset(10000, 0.0001)
@elapsed for _ in MLUtils.eachobsparallel(data, ThreadedEx()) end
@elapsed for _ in DataLoaders.eachobsparallel(data) end

data = TimeDataset(10000, 0.00001)
@elapsed for _ in MLUtils.eachobsparallel(data, ThreadedEx()) end
@elapsed for _ in DataLoaders.eachobsparallel(data) end
```

![image](https://user-images.githubusercontent.com/28812146/152222525-37cd00f8-37b0-4faf-91b3-9bdf55ba8a91.png)

That said, I still need to test how this translates to real-world performance by testing it on some FastAI.jl workloads, though I assume the overhead of either approach will be negligible for either approaches.

