### PR TITLE
add dims for chunk and test_zygote

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Carlo Lucibello <carlo.lucibello@gmail.com> and contributors"]
 version = "0.1.0"
 
 [deps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ShowCases = "605ecd9f-84a6-4c9e-81e2-4798472b76a3"
@@ -11,16 +12,16 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+ChainRulesCore = "1.0"
 ShowCases = "0.1"
 StatsBase = "0.33"
 julia = "1.6"
 
 [extras]
-ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["ChainRulesCore", "ChainRulesTestUtils", "SparseArrays", "Test", "Zygote"]
+test = ["ChainRulesTestUtils", "SparseArrays", "Test", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -16,8 +16,11 @@ StatsBase = "0.33"
 julia = "1.6"
 
 [extras]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["SparseArrays", "Test"]
+test = ["ChainRulesCore", "ChainRulesTestUtils", "SparseArrays", "Test", "Zygote"]

--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -6,7 +6,10 @@ using ShowCases: ShowLimit
 import StatsBase: sample
 using Base: @propagate_inbounds
 using Random: AbstractRNG, shuffle!, GLOBAL_RNG
-using ChainRulesCore
+import ChainRulesCore
+using ChainRulesCore: @non_differentiable, unthunk, AbstractZero, 
+                      NoTangent, ZeroTangent, ProjectTo
+
 
 include("observation.jl")
 export numobs, 

--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -6,6 +6,7 @@ using ShowCases: ShowLimit
 import StatsBase: sample
 using Base: @propagate_inbounds
 using Random: AbstractRNG, shuffle!, GLOBAL_RNG
+using ChainRulesCore
 
 include("observation.jl")
 export numobs, 

--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -6,7 +6,7 @@ using ShowCases: ShowLimit
 import StatsBase: sample
 using Base: @propagate_inbounds
 using Random: AbstractRNG, shuffle!, GLOBAL_RNG
-import ChainRulesCore
+import ChainRulesCore: rrule
 using ChainRulesCore: @non_differentiable, unthunk, AbstractZero, 
                       NoTangent, ZeroTangent, ProjectTo
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -185,7 +185,7 @@ end
 
 # Similar to ∇eachslice  https://github.com/JuliaDiff/ChainRules.jl/blob/8108a77a96af5d4b0c460aac393e44f8943f3c5e/src/rulesets/Base/indexing.jl#L77
 function ∇chunk(dys, x::AbstractArray, idxs, vd::Val{dim}) where {dim}
-    i1 = findfirst(dy -> dy isa AbstractArray, dys)
+    i1 = findfirst(dy -> !(dy isa AbstractZero), dys)
     if i1 === nothing  # all slices are Zero!
         return _zero_fill!(similar(x, float(eltype(x))))
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -161,9 +161,14 @@ julia> xs[1]
 chunk(x, n::Int) = collect(Iterators.partition(x, ceil(Int, length(x) / n)))
 
 function chunk(x::AbstractArray, n::Int; dims::Int=ndims(x))
-    bs = ceil(Int, size(x, dims) / n)    
-    [selectdim(x, dims, i) for i in Iterators.partition(axes(x, dims), bs)]
+    bs = ceil(Int, size(x, dims) / n)
+    ids = _partition(axes(x, dims), bs) 
+    [selectdim(x, dims, i) for i in ids]
 end
+
+# Zygote errors if not iterating over collected partitions in [selectdim(x, dims, i) for i in ids] 
+_partition(x, k) = collect(Iterators.partition(x, k))
+@non_differentiable _partition(x...)
 
 """
     group_counts(x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -168,10 +168,8 @@ end
 # Zygote errors if not iterating over collected partitions in [selectdim(x, dims, i) for i in ids] 
 function _partition_idxs(x, n, dims)
     bs = ceil(Int, size(x, dims) / n)
-    collect(Iterators.partition(axes(x, dims), bs))
+    Iterators.partition(axes(x, dims), bs)
 end
-
-@non_differentiable _partition_idxs(x...)
 
 function rrule(::typeof(chunk), x::AbstractArray, n::Int; dims::Int=ndims(x))
     # this is the implementation of chunk

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -178,7 +178,7 @@ function rrule(::typeof(chunk), x::AbstractArray, n::Int; dims::Int=ndims(x))
     idxs = _partition_idxs(x, n, dims) 
     y = [selectdim(x, dims, i) for i in idxs]
     
-    chunk_pullback(dy) = (NoTangent(), ∇chunk(unthunk(dy), x, idxs, Val(dims)))
+    chunk_pullback(dy) = (NoTangent(), ∇chunk(unthunk(dy), x, idxs, Val(dims)), NoTangent())
     
     return y, chunk_pullback
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -209,9 +209,8 @@ _zero_fill!(dx::AbstractArray) = map!(zero, dx, dx)
 function rrule(::typeof(∇chunk), dys, x, idxs, vd::Val{dim}) where dim
     n = length(dys)
     function ∇∇chunk(dz_raw)
-        dz = unthunk(dz_raw)
-        cs = chunk(dz, n; dims=dim)
-        return (NoTangent(), collect(cs), NoTangent(), NoTangent(), NoTangent())
+        dz = chunk(unthunk(dz_raw), n; dims=dim)
+        return (NoTangent(), dz, NoTangent(), NoTangent(), NoTangent())
     end
     return ∇chunk(dys, x, idxs, vd), ∇∇chunk
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -177,8 +177,8 @@ function rrule(::typeof(chunk), x::AbstractArray, n::Int; dims::Int=ndims(x))
     # this is the implementation of chunk
     idxs = _partition_idxs(x, n, dims) 
     y = [selectdim(x, dims, i) for i in idxs]
-    
-    chunk_pullback(dy) = (NoTangent(), ∇chunk(unthunk(dy), x, idxs, Val(dims)), NoTangent())
+    valdims = Val(dims)
+    chunk_pullback(dy) = (NoTangent(), ∇chunk(unthunk(dy), x, idxs, valdims), NoTangent())
     
     return y, chunk_pullback
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -165,7 +165,6 @@ function chunk(x::AbstractArray, n::Int; dims::Int=ndims(x))
     [selectdim(x, dims, i) for i in idxs]
 end
 
-# Zygote errors if not iterating over collected partitions in [selectdim(x, dims, i) for i in ids] 
 function _partition_idxs(x, n, dims)
     bs = ceil(Int, size(x, dims) / n)
     Iterators.partition(axes(x, dims), bs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,9 @@ using MLUtils.Datasets
 using SparseArrays
 using Random, Statistics
 using Test
+using ChainRulesTestUtils: test_rrule
+using Zygote: ZygoteRuleConfig 
+using ChainRulesCore: rrule_via_ad
 
 showcompact(io, x) = show(IOContext(io, :compact => true), x)
 
@@ -34,6 +37,8 @@ MLUtils.getobs(::CustomType, i::Int) = i
 MLUtils.getobs(::CustomType, i::AbstractVector) = collect(i)
 
 # --------------------------------------------------------------------
+
+include("test_utils.jl")
 
 # @testset "MLUtils.jl" begin
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,7 @@
+
+function test_zygote(f, xs...; kws...)
+    config = ZygoteRuleConfig()
+    test_rrule(config, f, xs...; kws..., rrule_f = rrule_via_ad)
+end
+
+test_zygote(chunk, rand(10), 3)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -3,5 +3,3 @@ function test_zygote(f, xs...; kws...)
     config = ZygoteRuleConfig()
     test_rrule(config, f, xs...; kws..., rrule_f = rrule_via_ad)
 end
-
-test_zygote(chunk, rand(10), 3)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -95,7 +95,17 @@ end
     cs[1] == [1  6; 2  7; 3  8; 4  9; 5 10]
     cs[2] == [11 16; 12 17; 13 18; 14 19; 15 20]
     
+    # test gradient
     test_zygote(chunk, rand(10), 3, check_inferred=false)
+
+    # indirect test of second order derivates
+    n = 2
+    dims = 2
+    x = rand(4, 5)
+    y = chunk(x, 2)
+    dy = randn!.(collect.(y))
+    idxs = MLUtils._partition_idxs(x, n, dims)
+    test_zygote(MLUtils.∇chunk, dy, x, idxs, Val(dims), check_inferred=false)
 end
 
 @testset "group_counts" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -95,7 +95,7 @@ end
     cs[1] == [1  6; 2  7; 3  8; 4  9; 5 10]
     cs[2] == [11 16; 12 17; 13 18; 14 19; 15 20]
     
-    test_zygote(chunk, rand(10), 3)
+    test_zygote(chunk, rand(10), 3, check_inferred=false)
 end
 
 @testset "group_counts" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -82,6 +82,20 @@ end
     @test cs[1] == [1, 2, 3, 4]
     @test cs[2] == [5, 6, 7, 8]
     @test cs[3] == [9, 10]
+
+    cs = chunk(collect(1:10), 3)
+    @test length(cs) == 3
+    @test cs[1] == [1, 2, 3, 4]
+    @test cs[2] == [5, 6, 7, 8]
+    @test cs[3] == [9, 10]
+    
+    x = reshape(collect(1:20), (5, 4))
+    cs = chunk(x, 2)
+    @test length(cs) == 2
+    cs[1] == [1  6; 2  7; 3  8; 4  9; 5 10]
+    cs[2] == [11 16; 12 17; 13 18; 14 19; 15 20]
+    
+    test_zygote(chunk, rand(10), 3)
 end
 
 @testset "group_counts" begin


### PR DESCRIPTION
Trying to fix https://github.com/FluxML/Flux.jl/issues/1841 using @mcabbott's suggestion, but Zygote has trouble differentiating through `Iterators.partition`, I get
```julia
julia> test_zygote(chunk, rand(10), 3)
test_rrule: chunk on Vector{Float64},Int64: Error During Test at /home/carlo/.julia/packages/ChainRulesTestUtils/XI7i2/src/testers.jl:195
  Got exception outside of a @test
  MethodError: no method matching size(::Base.Iterators.PartitionIterator{Base.OneTo{Int64}})
  Closest candidates are:
    size(::Union{LinearAlgebra.QR, LinearAlgebra.QRCompactWY, LinearAlgebra.QRPivoted}) at ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/LinearAlgebra/src/qr.jl:567
    size(::Union{LinearAlgebra.QR, LinearAlgebra.QRCompactWY, LinearAlgebra.QRPivoted}, ::Integer) at ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/LinearAlgebra/src/qr.jl:566
    size(::Union{LinearAlgebra.Cholesky, LinearAlgebra.CholeskyPivoted}) at ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/LinearAlgebra/src/cholesky.jl:494
    ...
  Stacktrace:
    [1] axes
      @ ./abstractarray.jl:95 [inlined]
    [2] _tryaxes(x::Base.Iterators.PartitionIterator{Base.OneTo{Int64}})
      @ Zygote ~/.julia/packages/Zygote/FPUm3/src/lib/array.jl:184
    [3] map
      @ ./tuple.jl:221 [inlined]
    [4] ∇map(cx::Zygote.Context, f::MLUtils.var"#70#71"{Int64, Vector{Float64}}, args::Base.Iterators.PartitionIterator{Base.OneTo{Int64}})
      @ Zygote ~/.julia/packages/Zygote/FPUm3/src/lib/array.jl:199
    [5] _pullback(cx::Zygote.Context, #unused#::typeof(collect), g::Base.Generator{Base.Iterators.PartitionIterator{Base.OneTo{Int64}}, MLUtils.var"#70#71"{Int64, Vector{Float64}}})
      @ Zygote ~/.julia/packages/Zygote/FPUm3/src/lib/array.jl:244
    [6] _pullback
      @ ~/.julia/dev/MLUtils/src/utils.jl:165 [inlined]
    [7] _pullback(::Zygote.Context, ::MLUtils.var"##chunk#69", ::Int64, ::typeof(chunk), ::Vector{Float64}, ::Int64)
      @ Zygote ~/.julia/packages/Zygote/FPUm3/src/compiler/interface2.jl:0
    [8] _pullback
      @ ~/.julia/dev/MLUtils/src/utils.jl:164 [inlined]
    [9] _pullback(::Zygote.Context, ::typeof(chunk), ::Vector{Float64}, ::Int64)
      @ Zygote ~/.julia/packages/Zygote/FPUm3/src/compiler/interface2.jl:0
```
As a workaround I can define a custom partition function I guess. 

cc @theabhirath @darsnack 