### PR TITLE
Make `getindex`/`length` the default interface

### DIFF
--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -22,7 +22,7 @@ export mapobs,
        groupobs,
        joinobs,
        shuffleobs
-       
+
 include("batchview.jl")
 export batchsize,
        BatchView

--- a/src/batchview.jl
+++ b/src/batchview.jl
@@ -100,7 +100,7 @@ Return the fixed size of each batch in `data`.
 """
 batchsize(A::BatchView) = A.batchsize
 
-numobs(A::BatchView) = A.count
+Base.length(A::BatchView) = A.count
 getobs(A::BatchView) = getobs(A.data)
 getobs(A::BatchView, i::Int) = getobs(A.data, _batchrange(A, i))
 

--- a/src/batchview.jl
+++ b/src/batchview.jl
@@ -119,6 +119,10 @@ function Base.getindex(A::BatchView, is::AbstractVector)
     obsview(A.data, obsindices)
 end
 
+# override AbstractDataContainer default
+Base.iterate(A::BatchView, state = 1) =
+    (state > numobs(A)) ? nothing : (A[state], state + 1)
+
 obsview(A::BatchView) = A
 obsview(A::BatchView, i) = A[i]
 

--- a/src/observation.jl
+++ b/src/observation.jl
@@ -74,6 +74,7 @@ getobs!(buffer, data, idx) = getobs(data, idx)
 
 abstract type AbstractDataContainer end
 
+Base.size(x::AbstractDataContainer) = (numobs(x),)
 Base.iterate(x::AbstractDataContainer, state = 1) =
     (state > numobs(x)) ? nothing : (getobs(x, state), state + 1)
 Base.lastindex(x::AbstractDataContainer) = numobs(x)

--- a/src/observation.jl
+++ b/src/observation.jl
@@ -2,8 +2,14 @@
     numobs(data)
 
 Return the total number of observations contained in `data`.
+
 If `data` does not have `numobs` defined, then this function
 falls back to `length(data)`.
+Authors of custom data containers should implement
+`Base.length` for their type instead of `numobs`.
+`numobs` should only be implemented for types where there is a
+difference between `numobs` and `Base.length`
+(such as multi-dimensional arrays).
 
 See also [`getobs`](@ref)
 """
@@ -18,16 +24,20 @@ numobs(data) = length(data)
 Return the observations corresponding to the observation-index `idx`.
 Note that `idx` can be any type as long as `data` has defined
 `getobs` for that type.
+
 If `data` does not have `getobs` defined, then this function
 falls back to `data[idx]`.
+Authors of custom data containers should implement
+`Base.getindex` for their type instead of `getobs`.
+`getobs` should only be implemented for types where there is a
+difference between `getobs` and `Base.getindex`
+(such as multi-dimensional arrays).
 
 The returned observation(s) should be in the form intended to
 be passed as-is to some learning algorithm. There is no strict
 interface requirement on how this "actual data" must look like.
-
 Every author behind some custom data container can make this
 decision themselves.
-
 The output should be consistent when `idx` is a scalar vs vector.
 
 See also [`getobs!`](@ref) and [`numobs`](@ref) 
@@ -64,13 +74,9 @@ getobs!(buffer, data, idx) = getobs(data, idx)
 
 abstract type AbstractDataContainer end
 
-Base.getindex(x::AbstractDataContainer, i) = getobs(x, i)
-Base.length(x::AbstractDataContainer) = numobs(x)
-Base.size(x::AbstractDataContainer) = (length(x),)
-
 Base.iterate(x::AbstractDataContainer, state = 1) =
-    (state > length(x)) ? nothing : (x[state], state + 1)
-Base.lastindex(x::AbstractDataContainer) = length(x)
+    (state > numobs(x)) ? nothing : (getobs(x, state), state + 1)
+Base.lastindex(x::AbstractDataContainer) = numobs(x)
 
 # --------------------------------------------------------------------
 # Arrays

--- a/src/obsview.jl
+++ b/src/obsview.jl
@@ -178,11 +178,10 @@ end
 
 Base.IteratorEltype(::Type{<:ObsView}) = Base.EltypeUnknown()
 
-# override AbstractDataContainer defaults
 Base.getindex(subset::ObsView, idx) =
     obsview(subset.data, subset.indices[idx])
 
-numobs(subset::ObsView) = length(subset.indices)
+Base.length(subset::ObsView) = length(subset.indices)
 
 getobs(subset::ObsView) = getobs(subset.data, subset.indices)
 getobs(subset::ObsView, idx) = getobs(subset.data, subset.indices[idx])


### PR DESCRIPTION
This removes the `getindex`/`length` defaults from `AbstractDataContainer`. Instead, types implementing the interface should implement `Base.getindex` or `Base.length` first, and only implement `getobs`/`numobs` when the fallback definitions don't apply.

Fixes #57.