### PR TITLE
DataLoader transducers reducible API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ShowCases = "605ecd9f-84a6-4c9e-81e2-4798472b76a3"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 
 [compat]
 ChainRulesCore = "1.0"

--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -7,6 +7,7 @@ using FLoops: @floop
 using FLoops.Transducers: Executor, ThreadedEx
 using FoldsThreads: TaskPoolEx
 import StatsBase: sample
+using Transducers
 using Base: @propagate_inbounds
 using Random: AbstractRNG, shuffle!, GLOBAL_RNG
 import ChainRulesCore: rrule

--- a/src/batchview.jl
+++ b/src/batchview.jl
@@ -123,16 +123,16 @@ batchsize(A::BatchView) = A.batchsize
 
 Base.length(A::BatchView) = A.count
 
-function getobs(A::BatchView)
+Base.@propagate_inbounds function getobs(A::BatchView)
     return _getbatch(A, 1:numobs(A.data))
 end
 
-function Base.getindex(A::BatchView, i::Int)
+Base.@propagate_inbounds function Base.getindex(A::BatchView, i::Int)
     obsindices = _batchrange(A, i)
     _getbatch(A, obsindices)
 end
 
-function Base.getindex(A::BatchView, is::AbstractVector)
+Base.@propagate_inbounds function Base.getindex(A::BatchView, is::AbstractVector)
     obsindices = union((_batchrange(A, i) for i in is)...)::Vector{Int}
     _getbatch(A, obsindices)
 end
@@ -155,8 +155,8 @@ Base.iterate(A::BatchView, state = 1) =
     (state > numobs(A)) ? nothing : (A[state], state + 1)
 
 # Helper function to translate a batch-index into a range of observations.
-function _batchrange(a::BatchView, batchindex::Int)
-    (batchindex > a.count || batchindex < 0) && throw(BoundsError())
+@inline function _batchrange(a::BatchView, batchindex::Int)
+    @boundscheck (batchindex > a.count || batchindex < 0) && throw(BoundsError())
     startidx = (batchindex - 1) * a.batchsize + 1
     endidx = min(numobs(a.data), startidx + a.batchsize -1)
     return startidx:endidx

--- a/src/batchview.jl
+++ b/src/batchview.jl
@@ -158,7 +158,7 @@ Base.iterate(A::BatchView, state = 1) =
 @inline function _batchrange(a::BatchView, batchindex::Int)
     @boundscheck (batchindex > a.count || batchindex < 0) && throw(BoundsError())
     startidx = (batchindex - 1) * a.batchsize + 1
-    endidx = min(numobs(a.data), startidx + a.batchsize -1)
+    endidx = min(a.imax, startidx + a.batchsize -1)
     return startidx:endidx
 end
 

--- a/src/eachobs.jl
+++ b/src/eachobs.jl
@@ -225,9 +225,9 @@ end
 
 @inline function _dataloader_foldl3(rf, val, e::DataLoader, data)
     if e.buffer > 0
-        _dataloader_foldl4_buffered(rf, val, e, data)
+        _dataloader_foldl4_buffered(rf, val, data)
     else
-        _dataloader_foldl4(rf, val, e, data)
+        _dataloader_foldl4(rf, val, data)
     end
 end
 

--- a/src/eachobs.jl
+++ b/src/eachobs.jl
@@ -207,7 +207,7 @@ Base.IteratorEltype(::DataLoader) = Base.EltypeUnknown()
 #     end)
 # end
 
-function _dataloader_foldl1(rf, val, e::DataLoader, data)
+@inline function _dataloader_foldl1(rf, val, e::DataLoader, data)
     if e.shuffle
         _dataloader_foldl2(rf, val, e, shuffleobs(e.rng, data))
     else
@@ -215,7 +215,7 @@ function _dataloader_foldl1(rf, val, e::DataLoader, data)
     end
 end
 
-function _dataloader_foldl2(rf, val, e::DataLoader, data)
+@inline function _dataloader_foldl2(rf, val, e::DataLoader, data)
     if e.batchsize > 0
         _dataloader_foldl3(rf, val, e, BatchView(data; e.batchsize, e.partial))
     else
@@ -223,7 +223,7 @@ function _dataloader_foldl2(rf, val, e::DataLoader, data)
     end
 end
 
-function _dataloader_foldl3(rf, val, e::DataLoader, data)
+@inline function _dataloader_foldl3(rf, val, e::DataLoader, data)
     if e.buffer > 0
         _dataloader_foldl4_buffered(rf, val, e, data)
     else
@@ -231,7 +231,7 @@ function _dataloader_foldl3(rf, val, e::DataLoader, data)
     end
 end
 
-function _dataloader_foldl4(rf, val, data)
+@inline function _dataloader_foldl4(rf, val, data)
     for i in 1:numobs(data)
         @inbounds x = getobs(data, i)
         # TODO: in 1.8 we could @inline this at the callsite,
@@ -242,7 +242,7 @@ function _dataloader_foldl4(rf, val, data)
     Transducers.complete(rf, val)
 end
 
-function _dataloader_foldl4_buffered(rf, val, data)
+@inline function _dataloader_foldl4_buffered(rf, val, data)
     buf = getobs(data, 1)
     for i in 1:numobs(data)
         @inbounds x = getobs!(buf, data, i)
@@ -251,7 +251,7 @@ function _dataloader_foldl4_buffered(rf, val, data)
     Transducers.complete(rf, val)
 end
 
-function Transducers.__foldl__(rf, val, e::DataLoader)
+@inline function Transducers.__foldl__(rf, val, e::DataLoader)
     e.parallel && throw(ArgumentError("Transducer fold protocol not supported on parallel data loads"))
     _dataloader_foldl1(rf, val, e, ObsView(e.data))
 end

--- a/src/eachobs.jl
+++ b/src/eachobs.jl
@@ -206,3 +206,40 @@ Base.IteratorEltype(::DataLoader) = Base.EltypeUnknown()
 #         e.data
 #     end)
 # end
+
+function _dataloader_foldl(rf, val, data)
+    for i in 1:numobs(data)
+        @inbounds x = getobs(data, i)
+        # TODO: in 1.8 we could @inline this at the callsite,
+        #       optimizer seems to be very sensitive to inlining and
+        #       quite brittle in its capacity to keep this type stable
+        val = Transducers.@next(rf, val, x)
+    end
+    Transducers.complete(rf, val)
+end
+
+function _dataloader_foldl_buffered(rf, val, data)
+    buf = getobs(data, 1)
+    for i in 1:numobs(data)
+        @inbounds x = getobs!(buf, data, i)
+        # TODO: in 1.8 we could @inline this at the callsite,
+        #       optimizer seems to be very sensitive to inlining and
+        #       quite brittle in its capacity to keep this type stable
+        val = Transducers.@next(rf, val, x)
+    end
+    Transducers.complete(rf, val)
+end
+
+function Transducers.__foldl__(rf, val, e::DataLoader)
+    e.parallel && throw(ArgumentError("Transducer fold protocol not supported on parallel data loads"))
+    data = ObsView(e.data)
+    data = e.shuffle ? shuffleobs(e.rng, data) : data
+    data = e.batchsize > 0 ? BatchView(data; e.batchsize, e.partial, e.collate) : data
+
+    # Indirect to type stabilize `data`
+    if e.buffer
+        _dataloader_foldl_buffered(rf, val, data)
+    else
+        _dataloader_foldl(rf, val, data)
+    end
+end

--- a/src/observation.jl
+++ b/src/observation.jl
@@ -131,8 +131,8 @@ numobs(data::Union{Tuple, NamedTuple}) = _check_numobs(data)
 
 getobs(tup::Union{Tuple, NamedTuple}) = map(x -> getobs(x), tup)
 
-function getobs(tup::Union{Tuple, NamedTuple}, indices)
-    _check_numobs(tup)
+Base.@propagate_inbounds function getobs(tup::Union{Tuple, NamedTuple}, indices)
+    @boundscheck _check_numobs(tup)
     return map(x -> getobs(x, indices), tup)
 end
 

--- a/src/obsview.jl
+++ b/src/obsview.jl
@@ -178,16 +178,16 @@ end
 
 Base.IteratorEltype(::Type{<:ObsView}) = Base.EltypeUnknown()
 
-Base.getindex(subset::ObsView, idx) =
+@propagate_inbounds Base.getindex(subset::ObsView, idx) =
     obsview(subset.data, subset.indices[idx])
 
 Base.length(subset::ObsView) = length(subset.indices)
 
 getobs(subset::ObsView) = getobs(subset.data, subset.indices)
-getobs(subset::ObsView, idx) = getobs(subset.data, subset.indices[idx])
+@propagate_inbounds getobs(subset::ObsView, idx) = getobs(subset.data, subset.indices[idx])
 
 getobs!(buffer, subset::ObsView) = getobs!(buffer, subset.data, subset.indices)
-getobs!(buffer, subset::ObsView, idx) = getobs!(buffer, subset.data, subset.indices[idx])
+@propagate_inbounds getobs!(buffer, subset::ObsView, idx) = getobs!(buffer, subset.data, subset.indices[idx])
 
 Base.parent(x::ObsView) = x.data
 

--- a/test/dataloader.jl
+++ b/test/dataloader.jl
@@ -181,4 +181,27 @@
             @test first(DataLoader(d, batchsize = 2, collate=true)) isa Vector
         end
     end
+
+    @testset "Transducers foldl" begin
+        dloader = DataLoader(1:10)
+        @test foldl(+, Map(x -> x[1]), dloader; init = 0) == 55
+
+        dloader = DataLoader(1:10; shuffle = true)
+        @test foldl(+, Map(x -> x[1]), dloader; init = 0) == 55
+
+        dloader = DataLoader(1:10; batchsize = 2)
+        @test foldl(+, Map(x -> x[1]), dloader; init = 0) == 25
+
+        dloader = DataLoader(1:1000; shuffle = false)
+        @test copy(Map(x -> x[1]), Vector{Int}, dloader) == collect(1:1000)
+
+        dloader = DataLoader(1:1000; shuffle = true)
+        @test copy(Map(x -> x[1]), Vector{Int}, dloader) != collect(1:1000)
+
+        dloader = DataLoader(1:1000; batchsize = 2, shuffle = false)
+        @test copy(Map(x -> x[1]), Vector{Int}, dloader) == collect(1:2:1000)
+
+        dloader = DataLoader(1:1000; batchsize = 2, shuffle = true)
+        @test copy(Map(x -> x[1]), Vector{Int}, dloader) != collect(1:2:1000)
+    end
 end

--- a/test/dataloader.jl
+++ b/test/dataloader.jl
@@ -185,6 +185,7 @@
     @testset "Transducers foldl" begin
         dloader = DataLoader(1:10)
         @test foldl(+, Map(x -> x[1]), dloader; init = 0) == 55
+        @inferred foldl(+, Map(x -> x[1]), dloader; init = 0)
 
         dloader = DataLoader(1:10; shuffle = true)
         @test foldl(+, Map(x -> x[1]), dloader; init = 0) == 55

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using MLUtils: RingBuffer, eachobsparallel
 using SparseArrays
 using Random, Statistics
 using Test
+using Transducers
 using FoldsThreads: TaskPoolEx
 using ChainRulesTestUtils: test_rrule
 using Zygote: ZygoteRuleConfig


### PR DESCRIPTION
With the set of runtime options available to `DataLoader`, the iteration protocol is not type stable.

This PR adds `Transducers` reducible support to `DataLoader`, to invert control flow, and type stabilize over iteration, as an alternative API.

Not directly related, I've added some inbounds propagation where I found it missing.