### PR TITLE
Change default scheduler for `eachobsparallel`

### DIFF
--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -70,7 +70,7 @@ end
 # since  `ThreadedEx` has shown to be more performant. This may
 # change in the future.
 # See PR 33 https://github.com/JuliaML/MLUtils.jl/pull/33
-_default_executor() = TaskPoolEx(basesize=1, background=true)
+_default_executor() = TaskPoolEx(basesize=1, background=Threads.nthreads() > 1)
 
 
 # ## Internals

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -70,7 +70,7 @@ end
 # since  `ThreadedEx` has shown to be more performant. This may
 # change in the future.
 # See PR 33 https://github.com/JuliaML/MLUtils.jl/pull/33
-_default_executor() = ThreadedEx(basesize=1)
+_default_executor() = TaskPoolEx(basesize=1, background=true)
 
 
 # ## Internals


### PR DESCRIPTION
This changes the default executor of `eachobsparallel` to use `TaskPoolEx(basesize=1, background=true)`. I did some more testing and found that this peforms on-par with DataLoaders.jl.

I used the following (CPU- and IO-heavy) benchmark:

```julia
using FastAI

data, blocks = loaddataset("imagenette2-320", (Image, Label))

for obs in tqdm(MLUtils.eachobsparallel(data, executor = TaskPoolEx(basesize=1, background=true)))

for obs in tqdm(DataLoaders.eachobsparallel(data, executor = TaskPoolEx(basesize=1, background=true)))
```

Both finish in 4.5s, reaching 3000samples/s throughput on my machine with Julia 1.7.2, `Threads.nthreads() == 12` (CPU: AMD Ryzen Threadripper 1920X 12-Core). Also tested on 1.8.0-beta3 with similar results.

This also fixes the issue with the previous default executor (`ThreadedEx`) that was so fast that it froze the primary thread and even other processes like the SSH server (as experienced by me and @darsnack).

Happy to say this was the last blocker before deprecating DataLoaders.jl and moving FastAI.jl to depend on MLUtils.jl (see https://github.com/FluxML/FastAI.jl/issues/196)