### PR TITLE
speedup `batch` of arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLUtils"
 uuid = "f1d291b0-491e-4a28-83b9-f70985020b54"
 authors = ["Carlo Lucibello <carlo.lucibello@gmail.com> and contributors"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -308,22 +308,17 @@ end
 
 batchindex(xs, i) = (reverse(Base.tail(reverse(axes(xs))))..., i)
 
-function batch(xs::AbstractArray{<:AbstractArray{T,N}}) where {T, N}
-    sz = size(xs)
-    y = stack(vec(xs), dims=N+1)
-    reshape(y, size(y)[1:N]..., sz...)
+function batch(xs::AbstractArray{<:AbstractArray})
+    # Don't use stack(xs, dims=N+1), it is much slower.
+    # Here we do reduce(vcat, xs) along with some reshapes.
+    szxs = length(xs)
+    @assert length(xs) > 0 "Minimum batch size is 1."
+    szx = size(xs[1])
+    @assert all(x -> size(x) == szx, xs) "All arrays must be of the same size."
+    vxs = vec(vec.(xs))
+    y = reduce(vcat, vxs)
+    return reshape(y, szx..., szxs...)
 end
-# function batch(xs::AbstractArray{<:AbstractArray})
-#     # Don't use stack(xs, dims=N+1), it is much slower.
-#     # Here we do reduce(vcat, xs) along with some reshapes.
-#     szxs = length(xs)
-#     @assert length(xs) > 0 "Minimum batch size is 1."
-#     szx = size(xs[1])
-#     @assert all(x -> size(x) == (szx), xs) "All arrays must be of the same size."
-#     vxs = vec(vec.(xs))
-#     y = reduce(vcat, vxs)
-#     return reshape(y, szx..., szxs...)
-# end
 
 function batch(xs::Vector{<:Tuple})
     @assert length(xs) > 0 "Input should be non-empty"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -362,7 +362,7 @@ julia> unbatch([1 3 5 7;
  [5, 6]
  [7, 8]
 """
-unbatch(x::AbstractArray) = unstack(x, dims=ndims(x))
+unbatch(x::AbstractArray) = [getobs(x, i) for i in 1:numobs(x)]
 unbatch(x::AbstractVector) = x
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -308,17 +308,22 @@ end
 
 batchindex(xs, i) = (reverse(Base.tail(reverse(axes(xs))))..., i)
 
-function batch(xs::AbstractArray{<:AbstractArray})
-    # Don't use stack(xs, dims=N+1), it is much slower.
-    # Here we do reduce(vcat, xs) along with some reshapes.
-    szxs = length(xs)
-    @assert length(xs) > 0 "Minimum batch size is 1."
-    szx = size(xs[1])
-    @assert all(x -> size(x) == (szx), xs) "All arrays must be of the same size."
-    vxs = vec(vec.(xs))
-    y = reduce(vcat, vxs)
-    return reshape(y, szx..., szxs...)
+function batch(xs::AbstractArray{<:AbstractArray{T,N}}) where {T, N}
+    sz = size(xs)
+    y = stack(vec(xs), dims=N+1)
+    reshape(y, size(y)[1:N]..., sz...)
 end
+# function batch(xs::AbstractArray{<:AbstractArray})
+#     # Don't use stack(xs, dims=N+1), it is much slower.
+#     # Here we do reduce(vcat, xs) along with some reshapes.
+#     szxs = length(xs)
+#     @assert length(xs) > 0 "Minimum batch size is 1."
+#     szx = size(xs[1])
+#     @assert all(x -> size(x) == (szx), xs) "All arrays must be of the same size."
+#     vxs = vec(vec.(xs))
+#     y = reduce(vcat, vxs)
+#     return reshape(y, szx..., szxs...)
+# end
 
 function batch(xs::Vector{<:Tuple})
     @assert length(xs) > 0 "Input should be non-empty"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -311,7 +311,7 @@ batchindex(xs, i) = (reverse(Base.tail(reverse(axes(xs))))..., i)
 function batch(xs::AbstractArray{<:AbstractArray})
     # Don't use stack(xs, dims=N+1), it is much slower.
     # Here we do reduce(vcat, xs) along with some reshapes.
-    szxs = length(xs)
+    szxs = size(xs)
     @assert length(xs) > 0 "Minimum batch size is 1."
     szx = size(xs[1])
     @assert all(x -> size(x) == szx, xs) "All arrays must be of the same size."

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -27,11 +27,9 @@ end
                     9 1 7 2
                     7 4 10 6 ]
     unstacked_array=[[8, 9, 9, 7], [9, 6, 1, 4], [3, 6, 7, 10], [5, 9, 2, 6]]
-    @test unbatch(stacked_array) == unstacked_array
-    @test batch(unstacked_array) == stacked_array
-
-    @test_broken @inferred(unbatch(stacked_array)) == unstacked_array
-    @test_broken @inferred(batch(unstacked_array)) == stacked_array
+    
+    @test @inferred(unbatch(stacked_array)) == unstacked_array
+    @test @inferred(batch(unstacked_array)) == stacked_array
 
     # no-op for vector of non-arrays
     @test batch([1,2,3]) == [1,2,3]


### PR DESCRIPTION
Previously `batch(xs)` was falling back to `stack(xs, dims=N+1)` that in turns calls `cat(xs...; dims=N+1)`. But for `stack` we can use `reduce(vcat, xs)` instead. 
```julia
using MLUtils, BenchmarkTools

function f(n)
    x = rand(Float32, 28, 28)
    return batch([x for i=1:n])
end

julia> @btime f(10);
  3.094 μs (28 allocations: 35.12 KiB)           # PR
  21.396 μs (139 allocations: 39.58 KiB)      # master

julia> @btime f(100);
  26.058 μs (208 allocations: 320.02 KiB)      # PR
  387.576 μs (1129 allocations: 433.50 KiB)   # master

julia> @btime f(1000);
  299.809 μs (2008 allocations: 3.09 MiB)    # PR
  27.570 ms (12023 allocations: 17.03 MiB)  # master
```
