### PR TITLE
Add `collate` argument to `BatchView`

### DIFF
--- a/src/batchview.jl
+++ b/src/batchview.jl
@@ -98,9 +98,10 @@ function BatchView(data::T; batchsize::Int=1, partial::Bool=true, collate=Val(no
 end
 
 _batchviewelemtype(data, batchsize, ::Val{nothing}) = typeof(obsview(data, 1:batchsize))
-# Better way to infer type of collated batch?
-_batchviewelemtype(data, _, ::Val{true}) = typeof(batch([getobs(data, 1)]))
-_batchviewelemtype(data, _, ::Val{false}) = Vector{typeof(getobs(data, 1))}
+_batchviewelemtype(::TData, _, ::Val{false}) where TData =
+    Vector{Core.Compiler.return_type(getobs, Tuple{TData, Int})}
+_batchviewelemtype(data, _, ::Val{true}) =
+    Core.Compiler.return_type(batch, Tuple{_batchviewelemtype(data, 0, Val(false))})
 
 """
     batchsize(data) -> Int

--- a/src/batchview.jl
+++ b/src/batchview.jl
@@ -113,7 +113,9 @@ batchsize(A::BatchView) = A.batchsize
 
 Base.length(A::BatchView) = A.count
 
-getobs(A::BatchView) = getobs(A.data)
+function getobs(A::BatchView)
+    return _getbatch(A, 1:numobs(A.data))
+end
 
 function Base.getindex(A::BatchView, i::Int)
     obsindices = _batchrange(A, i)

--- a/test/batchview.jl
+++ b/test/batchview.jl
@@ -1,7 +1,7 @@
 using MLUtils: obsview
 
 @testset "BatchView" begin
-    
+
     @testset "constructor" begin
         @test_throws DimensionMismatch BatchView((rand(2,10),rand(9)))
         @test_throws DimensionMismatch BatchView((rand(2,10),rand(9)))
@@ -10,7 +10,7 @@ using MLUtils: obsview
         for var in (vars..., tuples..., Xs, ys)
             @test_throws MethodError BatchView(var...)
             @test_throws MethodError BatchView(var, 16)
-            
+
             A = BatchView(var, batchsize=3)
             @test length(A) == 5
             @test batchsize(A) == 3
@@ -19,16 +19,13 @@ using MLUtils: obsview
         end
         A = BatchView(X, batchsize=16)
         @test length(A) == 1
-        @test batchsize(A) == 15            
+        @test batchsize(A) == 15
     end
 
 
     @testset "typestability" begin
-        for var in (vars..., tuples..., Xs, ys)
-            @test typeof(@inferred(BatchView(var))) <: BatchView
-            @test typeof(@inferred(BatchView(var, batchsize=3))) <: BatchView
-            @test typeof(@inferred(BatchView(var, batchsize=3, partial=true))) <: BatchView
-            @test typeof(@inferred(BatchView(var, batchsize=3, partial=false))) <: BatchView
+        for var in (vars..., tuples..., Xs, ys), batchsize in (1, 3), partial in (true, false), collate in (Val(true), Val(false), Val(nothing))
+            @test typeof(@inferred(BatchView(var; batchsize, partial, collate))) <: BatchView
         end
         @test typeof(@inferred(BatchView(CustomType()))) <: BatchView
     end
@@ -68,7 +65,7 @@ using MLUtils: obsview
             A = BatchView(var, batchsize=3)
             @test getobs(@inferred(ObsView(A))) == @inferred(getobs(A))
             @test_throws BoundsError ObsView(A,1:6)
-            
+
             S = @inferred(ObsView(A, 1:2))
             @test typeof(S) <: ObsView
             @test @inferred(numobs(S)) == 2
@@ -77,7 +74,7 @@ using MLUtils: obsview
             @test getobs(@inferred(A[1:2])) == getobs(S)
             @test @inferred(getobs(A,1:2)) == getobs(S)
             @test @inferred(getobs(S)) == getobs(BatchView(ObsView(var,1:6),batchsize=3))
-            
+
             S = @inferred(ObsView(A, 1:2))
             @test typeof(S) <: ObsView
         end

--- a/test/batchview.jl
+++ b/test/batchview.jl
@@ -22,6 +22,12 @@ using MLUtils: obsview
         @test batchsize(A) == 15
     end
 
+    @testset "collated" begin
+        @test BatchView(X, batchsize=2, collate=true)[1] |> size == (4, 2)
+        @test BatchView(X, batchsize=2, collate=false)[1] |> size == (2,)
+        @test size.(BatchView(tuples[1], batchsize=2, collate=true)[1]) == ((4, 2), (2,))
+        @test BatchView(tuples[1], batchsize=2, collate=false)[1] |> size == (2,)
+    end
 
     @testset "typestability" begin
         for var in (vars..., tuples..., Xs, ys), batchsize in (1, 3), partial in (true, false), collate in (Val(true), Val(false), Val(nothing))


### PR DESCRIPTION
This adds a `collate` kwarg to `BatchView` with the following options:

- `nothing` (default): same as previously (`obsview(data, is)`)
- `false`: `[getobs(data, i) for i in is]`
- `true`: `batch([getobs(data, i) for i in is])`

The reason collation was added to `BatchView` itself and not made a wrapper is that this will allow adding support for in-place, collated `getobs!` later on.

I've made sure `BatchView` remains type-stable by dispatching on the `collate` option, with some caveats:

- I'm not sure how to get the return type of `batch` which is needed as a type argument for `BatchView` (current solution evaluates `batch(getobs(...))` which should be avoided
- There is a type instability when taking a `BatchView((x1, x2), collate=true)` i.e. a collated batch view of a tuple. This comes from a type instability in `batch([(rand(10), "hello")])`. This one explains the failing tests.

Additional comments:

- there were implementations for both `getobs` and `getindex`; I assume only `getindex` is needed?
- `getobs(A::BatchView)` is currently defined as `getobs(A.data)` which doesn't do any batching. I would have thought that it should simply return all the batches

To-do:

- fix type instability in `batch` -> different PR
- [x] find better way to infer output type of `batch`
- [x] add inferrability tests for new combinations of arguments
- [x] add tests for collating 
- [x] update docstring

---

I hope the way I tried to tackle type stability is useful, if not, please let me know!