### PR TITLE
fix `unbatch` example doc

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -361,6 +361,7 @@ julia> unbatch([1 3 5 7;
  [3, 4]
  [5, 6]
  [7, 8]
+```                                                                                          
 """
 unbatch(x::AbstractArray) = [getobs(x, i) for i in 1:numobs(x)]
 unbatch(x::AbstractVector) = x


### PR DESCRIPTION
While going through `Flux.jl` documentation, i found that example for `unbatch` is not displaced correctly and found that this is because of missing closing ```. So this small PR is towards fixing this !! 