### PR TITLE
Add shuffleobs specific to BatchView

### DIFF
--- a/src/batchview.jl
+++ b/src/batchview.jl
@@ -172,4 +172,14 @@ function Base.showarg(io::IO, A::BatchView, toplevel)
     toplevel && print(io, " with eltype ", nameof(eltype(A))) # simplify
 end
 
+"""
+    shuffleobs(rng::AbstractRNG, data::BatchView)
+
+Returns a new `BatchView` with the observations shuffled into a new set of batches.
+"""
+function shuffleobs(rng::AbstractRNG, data::BatchView{TElem,TData,Val{Collate}}) where {TElem,TData,Collate}
+    obs = shuffleobs(rng, data.data)
+    return BatchView(obs; batchsize=data.batchsize, partial=data.partial, collate=Collate)
+end
+
 # --------------------------------------------------------------------

--- a/test/batchview.jl
+++ b/test/batchview.jl
@@ -96,6 +96,15 @@ using MLUtils: obsview
         @test getobs(ov, 1) == x[:,1:2]
     end
 
+    @testset "shuffleobs" begin
+        for var in (vars..., tuples..., Xs, ys), collate in [true, false, nothing]
+            A = BatchView(var; batchsize=3, collate)
+            S = @inferred BatchView shuffleobs(A)
+            @test typeof(S) <: BatchView
+            @test any(x -> x ∉ A, S)
+        end
+    end
+
     # @testset "nesting with ObsView" begin
     #     for var in vars
     #         @test eltype(@inferred(BatchView(ObsView(var)))[1]) <: Union{SubArray,String}


### PR DESCRIPTION
Alternate Fix for #96

This PR adds a `shuffleobs(rng::AbstractRNG, data::BatchView)` method for reshuffling the observations backing the input BatchView.