### PR TITLE
oversample and undersample always return classes as well

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLUtils"
 uuid = "f1d291b0-491e-4a28-83b9-f70985020b54"
 authors = ["Carlo Lucibello <carlo.lucibello@gmail.com> and contributors"]
-version = "0.2.12"
+version = "0.3.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -4,7 +4,9 @@
     y2 = ["c", "c", "c", "a", "b"]
     
     o = oversample((x, ya), fraction=1, shuffle=false) 
-    @test o == oversample((x, ya), ya, shuffle=false) 
+    @test o == oversample((x, ya), ya, shuffle=false)[1]
+    xo, yo = oversample(x, ya, shuffle=false)
+    @test (xo, yo) == o
     ox, oy = getobs(o)
     @test ox isa Matrix
     @test oy isa Vector 
@@ -15,7 +17,7 @@
     @test oy[1:5] == ya
     @test oy[6] == ya[5]
 
-    o = oversample((x, ya), y2, shuffle=false) 
+    o = oversample((x, ya), y2, shuffle=false)[1] 
     ox, oy = getobs(o)
     @test ox isa Matrix
     @test oy isa Vector 
@@ -35,6 +37,8 @@ end
     y2 = ["c", "c", "c", "a", "b"]
     
     o = undersample((x, ya), shuffle=false) 
+    xo, yo = undersample(x, ya, shuffle=false)
+    @test (xo, yo) == o
     ox, oy = getobs(o)
     @test ox isa Matrix
     @test oy isa Vector 
@@ -42,7 +46,7 @@ end
     @test size(oy) == (3,)
     @test ox[:,3] == x[:,5]
     
-    o = undersample((x, ya), y2, shuffle=false) 
+    o = undersample((x, ya), y2, shuffle=false)[1] 
     ox, oy = getobs(o)
     @test ox isa Matrix
     @test oy isa Vector 


### PR DESCRIPTION
Fix #113 by having the implementation adhere to the docs instead of changing the docs. 
The resampled classes are now always returned.

Also, made the under/oversample calls deterministic when `shuffle=false`. 

Since the change is breaking with respect to previous behavior (but non-breaking with respect to the behavior declaimed in the docs) I'm also updating the minor version. 
