### PR TITLE
Add compat for DelimitedFiles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 
 [compat]
 ChainRulesCore = "1.0"
+DelimitedFiles = "1.0"
 FLoops = "0.2"
 FoldsThreads = "0.1"
 ShowCases = "0.1"


### PR DESCRIPTION
Julia nightly moves DelimitedFiles out of Base, so it needs a compat version. This is causing downstream nightly failures on Metalhead.