### PR TITLE
Pretty printing for `DataLoader`

### DIFF
--- a/src/eachobs.jl
+++ b/src/eachobs.jl
@@ -255,3 +255,29 @@ end
     e.parallel && throw(ArgumentError("Transducer fold protocol not supported on parallel data loads"))
     _dataloader_foldl1(rf, val, e, ObsView(e.data))
 end
+
+function Base.show(io::IO, e::DataLoader)
+    print(io, "DataLoader(")
+    Base.showarg(io, e.data, false)
+    e.buffer == false || print(io, ", buffer=", e.buffer)
+    e.parallel == false || print(io, ", parallel=", e.parallel)
+    e.shuffle == false || print(io, ", shuffle=", e.shuffle)
+    e.batchsize == 1 || print(io, ", batchsize=", e.batchsize)
+    e.partial == true || print(io, ", partial=", e.partial)
+    e.collate == Val(nothing) || print(io, ", collate=", e.collate)
+    e.rng == Random.GLOBAL_RNG || print(io, ", rng=", e.rng)
+    print(io, ")")
+end
+
+function Base.show(io::IO, m::MIME"text/plain", e::DataLoader)
+    print(io, length(e), "-element ")
+    show(io, e)
+    # print(io, " for ", numobs(e.data), " observations,")
+    println(io, "\n  starting with:")
+    print(io, "  ", _summary(first(e)))
+end
+
+_summary(x) = summary(x)
+_summary(xs::Tuple) = "tuple(" * join([_summary(x) for x in xs], ", ") * ")"
+_summary(xs::NamedTuple) = "(; " * join(["$k = "*_summary(x) for (k,x) in zip(keys(xs),xs)], ", ") * ")"
+

--- a/test/dataloader.jl
+++ b/test/dataloader.jl
@@ -214,4 +214,25 @@
         dloader = DataLoader(1:1000; batchsize = 2, shuffle = true)
         @test copy(Map(x -> x[1]), Vector{Int}, dloader) != collect(1:2:1000)
     end
+    
+    @testset "printing" begin
+        X2 = reshape(Float32[1:10;], (2, 5))
+        Y2 = [1:5;]
+
+        d = DataLoader((X2, Y2), batchsize=3)
+        
+        @test contains(repr(d), "DataLoader(::Tuple{Matrix")
+        @test contains(repr(d), "batchsize=3")
+
+        @test contains(repr(MIME"text/plain"(), d), "2-element DataLoader")
+        @test contains(repr(MIME"text/plain"(), d), "2×3 Matrix{Float32}, 3-element Vector")
+        
+        d2 = DataLoader((x = X2, y = Y2), batchsize=2, partial=false)
+
+        @test contains(repr(d2), "DataLoader(::NamedTuple")
+        @test contains(repr(d2), "partial=false")
+
+        @test contains(repr(MIME"text/plain"(), d2), "2-element DataLoader(::NamedTuple")
+        @test contains(repr(MIME"text/plain"(), d2), "x = 2×2 Matrix{Float32}, y = 2-element Vector")
+    end
 end


### PR DESCRIPTION
Before:
```julia
julia> array_loader
DataLoader{Matrix{Float64}, Random._GLOBAL_RNG}([0.4162601998517451 0.6319257141697698 … 
0.3534065570971672 0.2042920171820276; 0.6498054094075275 0.5207088722535103 … 
0.6810047653022318 0.15479239537021516; … ; 0.43750205789271324 0.9278765112318127 … 
0.4973122624864813 0.4984282396624422; 0.8271657274672851 0.4403513166790436 … 
0.9147954294101035 0.08763411914124453], 2, 100, true, false, Random._GLOBAL_RNG())

julia> train_loader
DataLoader{NamedTuple{(:data, :label), Tuple{Matrix{Float64}, Vector{Char}}}, 
Random._GLOBAL_RNG}((data = [0.4162601998517451 0.6319257141697698 … 
0.3534065570971672 0.2042920171820276; 0.6498054094075275 0.5207088722535103 … 
0.6810047653022318 0.15479239537021516; … ; 0.43750205789271324 0.9278765112318127 … 
0.4973122624864813 0.4984282396624422; 0.8271657274672851 0.4403513166790436 … 
0.9147954294101035 0.08763411914124453], label = ['q', 'l', 'p', 'g', 'h', 'i', 'f', 'z', 'b', 'q'  …  'y', 'q', 'r', 
'j', 'q', 'q', 'u', 'c', 'p', 'p']), 5, 100, true, true, Random._GLOBAL_RNG())
```
After:
```julia
julia> array_loader
50-element DataLoader(::Matrix{Float64}, batchsize=2)
  starting with:
  10×2 Matrix{Float64}

julia> train_loader
20-element DataLoader(::NamedTuple{(:data, :label), Tuple{Matrix{Float64}, Vector{Char}}}, 
shuffle=true, batchsize=5)
  starting with:
  (; data = 10×5 Matrix{Float64}, label = 5-element Vector{Char})
```
This prints a summary, because it seems useful to see the types & sizes. To see any actual data, you would have to call `first(ans)` or something. 

Thoughts? 