### PR TITLE
Let `DataLoader(..., batchsize=0)` produce one batch

### DIFF
--- a/src/eachobs.jl
+++ b/src/eachobs.jl
@@ -56,7 +56,8 @@ The original data is preserved in the `data` field of the DataLoader.
 - `data`: The data to be iterated over. The data type has to be supported by
   [`numobs`](@ref) and [`getobs`](@ref).
 - `batchsize`: If less than 0, iterates over individual observations.
-  Otherwise, each iteration (except possibly the last) yields a mini-batch
+  If 0, then one mini-batch containing all `numobs(x)` observations.
+  If larger than 0, each iteration (except possibly the last) yields a mini-batch
   containing `batchsize` observations. Default `1`.
 - `buffer`: If `buffer=true` and supported by the type of `data`,
   a buffer will be allocated and reused for memory efficiency.
@@ -149,6 +150,7 @@ function DataLoader(
     if !(collate ∈ (Val(nothing), Val(true), Val(false)))
         throw(ArgumentError("`collate` must be one of `nothing`, `true` or `false`."))
     end
+    batchsize = batchsize == 0 ? numobs(data) : batchsize
     return DataLoader(data, batchsize, buffer, partial, shuffle, parallel, collate, rng)
 end
 


### PR DESCRIPTION
Closes #144

Before, treats 0 like "less than 0", perhaps we can call that a bug?
```julia
julia> DataLoader([1 2 3; 4 5 6]; batchsize=0)
3-element DataLoader(::Matrix{Int64}, batchsize=0)
  with first element:
  2-element Vector{Int64}

julia> collect(ans)
3-element Vector{Vector{Int64}}:
 [1, 4]
 [2, 5]
 [3, 6]

help?> DataLoader
search: DataLoader

  DataLoader(data; [batchsize, buffer, collate, parallel, partial, rng, shuffle])
[...]
    •  batchsize: If less than 0, iterates over individual observations. Otherwise, each
       iteration (except possibly the last) yields a mini-batch containing batchsize
       observations. Default 1.
[...]

julia> BatchView(1:10, batchsize=0) |> collect
ERROR: DivideError: integer division error
```
After, converts 0 to numobs on construction:
```julia
julia> DataLoader([1 2 3; 4 5 6]; batchsize=0)
1-element DataLoader(::Matrix{Int64}, batchsize=3)
  with first element:
  2×3 Matrix{Int64}

julia> BatchView(1:10, batchsize=0) |> collect  # unchanged
ERROR: DivideError: integer division error
```

Needs tests, but locally, tests passed with this change. That's some evidence that the zero wasn't really an intentional feature. (In addition to the doc saying "If less than 0".)