### PR TITLE
Add `firstindex(::AbstractDataContainer)`

### DIFF
--- a/src/observation.jl
+++ b/src/observation.jl
@@ -142,6 +142,7 @@ Base.size(x::AbstractDataContainer) = (numobs(x),)
 Base.iterate(x::AbstractDataContainer, state = 1) =
     (state > numobs(x)) ? nothing : (getobs(x, state), state + 1)
 Base.lastindex(x::AbstractDataContainer) = numobs(x)
+Base.firstindex(::AbstractDataContainer) = 1
 
 # --------------------------------------------------------------------
 # Arrays

--- a/test/obsview.jl
+++ b/test/obsview.jl
@@ -31,6 +31,7 @@
             @test @inferred(getobs(subset)) == getobs(var)
             @test @inferred(ObsView(subset)) === subset
             @test @inferred(ObsView(subset, 1:15)) === subset
+            @test subset[begin] == obsview(var, 1)
             @test subset[end] == obsview(var, 15)
             @test @inferred(subset[15]) == obsview(var, 15)
             @test @inferred(subset[2:5]) == obsview(var, 2:5)
@@ -178,6 +179,7 @@ end
             @test @inferred(A[1]) == obsview(var, 1)
             @test @inferred(A[11]) == obsview(var, 11)
             @test @inferred(A[15]) == obsview(var, 15)
+            @test A[begin] == A[1]
             @test A[end] == A[15]
             @test @inferred(getobs(A,1)) == getobs(var, 1)
             @test @inferred(getobs(A,11)) == getobs(var, 11)


### PR DESCRIPTION
This enables the `begin` keyword when indexing an
`AbstractDataContainer`. Note that `end` already worked when indexing
because of `lastindex(::AbstractDataContainer)` is already implemented. For example:

```julia
julia> using MLDatasets

julia> mnist = MNIST()

julia> x, y = mnist[begin]
(features = Float32[0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0], targets = 5)
```
