### PR TITLE
update `unstake` docstring

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -62,7 +62,7 @@ Base.show_function(io::IO, u::Base.Fix2{typeof(_unsqueeze)}, ::Bool) = print(io,
 
 Unroll the given `xs` into an array of arrays along the given dimension `dims`.
 
-See also [`stack`](@ref), [`unbatch`](@ref),
+See also [`stack`](https://docs.julialang.org/en/v1/base/arrays/#Base.stack), [`unbatch`](@ref),
 and [`chunk`](@ref).
 
 # Examples


### PR DESCRIPTION
Since `stack` function removed now, this link will 404

 I update link to point to `Base.stack`