### PR TITLE
support for collate function and for mapobs in DataLoader

### DIFF
--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -10,7 +10,7 @@ using Transducers
 using Tables
 using DataAPI
 using Base: @propagate_inbounds
-using Random: AbstractRNG, shuffle!, GLOBAL_RNG, rand!, randn!
+using Random: AbstractRNG, shuffle!, rand!, randn!
 import ChainRulesCore: rrule
 using ChainRulesCore: @non_differentiable, unthunk, AbstractZero,
                       NoTangent, ZeroTangent, ProjectTo

--- a/src/batchview.jl
+++ b/src/batchview.jl
@@ -105,7 +105,7 @@ function BatchView(data::T; batchsize::Int=1, partial::Bool=true, collate=Val(no
         batchsize = n
     end
     if collate === nothing || collate isa Bool
-        collate = collate = Val(collate)
+        collate = Val(collate)
     end
     if collate === Val(true)
         collate = MLUtils.batch

--- a/src/batchview.jl
+++ b/src/batchview.jl
@@ -15,7 +15,7 @@ If used as an iterator, the object will iterate over the dataset
 once, effectively denoting an epoch. 
 
 Any data access is delayed until iteration or indexing is perfomed. 
-The [`Flux.getobs`](@ref) function is called on the data object to retrieve the
+The [`getobs`](@ref MLUtils.getobs) function is called on the data object to retrieve the
 observations.
 
 For `BatchView` to work on some data structure, the type of the

--- a/src/batchview.jl
+++ b/src/batchview.jl
@@ -95,7 +95,7 @@ struct BatchView{TElem,TData,TCollate} <: AbstractDataContainer
     batchsize::Int
     count::Int
     partial::Bool
-    collate::TCollate
+    collate::TCollate # either Val(nothing), Val(false), or a function
 end
 
 function BatchView(data::T; batchsize::Int=1, partial::Bool=true, collate=Val(nothing)) where {T}

--- a/src/eachobs.jl
+++ b/src/eachobs.jl
@@ -219,6 +219,70 @@ Base.IteratorEltype(::DataLoader) = Base.EltypeUnknown()
 #     end)
 # end
 
+"""
+    mapobs(f, d::DataLoader)
+
+Return a new dataloader based on `d`  that applies `f` at each iteration. 
+
+# Examples
+
+```jldoctest
+julia> X = ones(3, 6);
+
+julia> function f(x)
+           @show x
+           return x
+       end
+f (generic function with 1 method)
+
+julia> d = DataLoader(X, batchsize=2, collate=false);
+
+julia> d = mapobs(f, d);
+
+julia> for x in d
+           @assert size(x) == (2,)
+           @assert size(x[1]) == (3,)
+       end
+x = [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]
+x = [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]
+x = [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]
+
+julia> d2 = DataLoader(X, batchsize=2, collate=true);
+
+julia> d2 = mapobs(f, d2);
+
+julia> for x in d2
+           @assert size(x) == (3, 2)
+       end
+x = [1.0 1.0; 1.0 1.0; 1.0 1.0]
+x = [1.0 1.0; 1.0 1.0; 1.0 1.0]
+x = [1.0 1.0; 1.0 1.0; 1.0 1.0]
+```
+"""
+function mapobs(f, d::DataLoader)
+    @assert d.batchsize > 0 "Mapping over individual observations is not supported, set `batchsize > 0` 
+    or apply mapobs to the underlying data container."
+   
+    @assert d.collate !== Val(nothing) "`collate==nothing` not supported by mapobs"
+    if d.collate == Val(false)
+        collate = f
+    elseif d.collate === Val(true)
+        collate = f ∘ batch
+    else
+        collate = f ∘ d.collate
+    end
+
+    DataLoader(d.data,
+               batchsize=d.batchsize,
+               buffer=d.buffer,
+               partial=d.partial,
+               shuffle=d.shuffle,
+               parallel=d.parallel,
+               collate=collate,
+               rng=d.rng)
+end
+
+
 @inline function _dataloader_foldl1(rf, val, e::DataLoader, data)
     if e.shuffle
         _dataloader_foldl2(rf, val, e, shuffleobs(e.rng, data))

--- a/src/eachobs.jl
+++ b/src/eachobs.jl
@@ -131,8 +131,8 @@ julia> foreach(println∘summary, DataLoader(rand(Int8, 10, 64), batchsize=30)) 
 
 julia> collate_fn(batch) = join(batch);
 
-julia> first(DataLoader(["a", "b", "c", "d"], batchsize=2, collate=collate_fn)) == "ab"
-true
+julia> first(DataLoader(["a", "b", "c", "d"], batchsize=2, collate=collate_fn))
+"ab"
 ```
 """
 struct DataLoader{T,B,C,R<:AbstractRNG}

--- a/src/eachobs.jl
+++ b/src/eachobs.jl
@@ -60,7 +60,7 @@ The original data is preserved in the `data` field of the DataLoader.
   containing `batchsize` observations. Default `1`.
 - **`buffer`**: If `buffer=true` and supported by the type of `data`,
   a buffer will be allocated and reused for memory efficiency.
-  You can also pass a preallocated object to `buffer`. Default `false`.
+  May want to set `partial=false` to avoid size mismatch. Default `false`. 
 - **`collate`**: Defines the batching behavior. Default `nothing`. 
   - If `nothing` , a batch is `getobs(data, indices)`. 
   - If `false`, each batch is `[getobs(data, i) for i in indices]`. 
@@ -147,15 +147,14 @@ end
 
 function DataLoader(
         data;
-        buffer = false,
-        parallel = false,
-        shuffle = false,
+        buffer::Bool = false,
+        parallel::Bool = false,
+        shuffle::Bool = false,
         batchsize::Int = 1,
         partial::Bool = true,
         collate = Val(nothing),
         rng::AbstractRNG = Random.default_rng())
 
-    buffer = buffer isa Bool ? buffer : true
     if collate isa Bool || collate === nothing
         collate = Val(collate)
     end

--- a/src/eachobs.jl
+++ b/src/eachobs.jl
@@ -89,7 +89,7 @@ The original data is preserved in the `data` field of the DataLoader.
 ```jldoctest
 julia> Xtrain = rand(10, 100);
 
-julia> array_loader = DataLoader(Xtrain, batchsize=2
+julia> array_loader = DataLoader(Xtrain, batchsize=2);
 
 julia> for x in array_loader
          @assert size(x) == (10, 2)
@@ -129,8 +129,7 @@ julia> foreach(println∘summary, DataLoader(rand(Int8, 10, 64), batchsize=30)) 
 10×30 Matrix{Int8}
 10×4 Matrix{Int8}
 
-
-julia> collate_fn(batch) = join(batch)
+julia> collate_fn(batch) = join(batch);
 
 julia> first(DataLoader(["a", "b", "c", "d"], batchsize=2, collate=collate_fn)) == "ab"
 true

--- a/src/eachobs.jl
+++ b/src/eachobs.jl
@@ -60,7 +60,9 @@ The original data is preserved in the `data` field of the DataLoader.
   containing `batchsize` observations. Default `1`.
 - **`buffer`**: If `buffer=true` and supported by the type of `data`,
   a buffer will be allocated and reused for memory efficiency.
-  May want to set `partial=false` to avoid size mismatch. Default `false`. 
+  May want to set `partial=false` to avoid size mismatch. 
+  Finally, can pass an external buffer to be used in `getobs!(buffer, data, idx)`.
+  Default `false`. 
 - **`collate`**: Defines the batching behavior. Default `nothing`. 
   - If `nothing` , a batch is `getobs(data, indices)`. 
   - If `false`, each batch is `[getobs(data, i) for i in indices]`. 
@@ -134,10 +136,10 @@ julia> first(DataLoader(["a", "b", "c", "d"], batchsize=2, collate=collate_fn)) 
 true
 ```
 """
-struct DataLoader{T, R<:AbstractRNG, C}
+struct DataLoader{T,B,C,R<:AbstractRNG}
     data::T
     batchsize::Int
-    buffer::Bool
+    buffer::B
     partial::Bool
     shuffle::Bool
     parallel::Bool
@@ -147,7 +149,7 @@ end
 
 function DataLoader(
         data;
-        buffer::Bool = false,
+        buffer = false,
         parallel::Bool = false,
         shuffle::Bool = false,
         batchsize::Int = 1,
@@ -168,7 +170,7 @@ end
 function Base.iterate(d::DataLoader)
     # TODO move ObsView and BatchWView wrapping to the constructor, so that 
     # we can parametrize the DataLoader with ObsView and BatchView and define specialized methods.
-    
+
     # Wrapping with ObsView in order to work around
     # issue https://github.com/FluxML/Flux.jl/issues/1935
     data = ObsView(d.data)

--- a/src/observation.jl
+++ b/src/observation.jl
@@ -128,6 +128,10 @@ because the type of `data` may not lend itself to the concept
 of `copy!`. Thus, supporting a custom `getobs!` is optional
 and not required.
 
+Custom implementations of `getobs!` should be consistent with
+[`getobs`](@ref) in terms of the output format,
+that is `getobs!(buffer, data, idx) == getobs(data, idx)`.
+
 See also [`getobs`](@ref) and [`numobs`](@ref). 
 """
 function getobs! end

--- a/src/obstransform.jl
+++ b/src/obstransform.jl
@@ -226,7 +226,7 @@ For this function to work, the type of `data` must implement
 [`numobs`](@ref) and [`getobs`](@ref). See [`ObsView`](@ref)
 for more information.
 """
-shuffleobs(data) = shuffleobs(Random.GLOBAL_RNG, data)
+shuffleobs(data) = shuffleobs(Random.default_rng(), data)
 
 function shuffleobs(rng::AbstractRNG, data)
     obsview(data, randperm(rng, numobs(data)))

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -43,7 +43,8 @@ function _eachobsparallel_buffered(
         data,
         executor;
         channelsize=Threads.nthreads())
-    buffers = [getobs(data, 1)]
+    buffer = getobs(data, 1)
+    buffers = [buffer]
     foreach(_ -> push!(buffers, deepcopy(buffer)), 1:channelsize)
 
     # This ensures the `Loader` will take from the `RingBuffer`s result

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -29,7 +29,7 @@
 function eachobsparallel(
         data;
         executor::Executor = _default_executor(),
-        buffer = false,
+        buffer::Bool = false,
         channelsize = Threads.nthreads())
     if buffer
         return _eachobsparallel_buffered(data, executor; channelsize)
@@ -42,9 +42,8 @@ end
 function _eachobsparallel_buffered(
         data,
         executor;
-        buffer = getobs(data, 1),
         channelsize=Threads.nthreads())
-    buffers = [buffer]
+    buffers = [getobs(data, 1)]
     foreach(_ -> push!(buffers, deepcopy(buffer)), 1:channelsize)
 
     # This ensures the `Loader` will take from the `RingBuffer`s result

--- a/test/batchview.jl
+++ b/test/batchview.jl
@@ -116,4 +116,16 @@ using MLUtils: obsview
         @test bv[2] == 6:10
         @test_throws BoundsError bv[3]
     end
+
+    @testset "collate function" begin
+        function collate_fn(batch)
+            # collate observations into a custom batch
+            return hcat([x[1] for x in batch]...), join([x[2] for x in batch])
+        end
+
+        for (x, y) in BatchView((rand(10, 4), ["a", "b", "c", "d"]), batchsize=2, collate=collate_fn)
+            @test size(x) == (10, 2)
+            @test y isa String
+        end
+    end
 end

--- a/test/dataloader.jl
+++ b/test/dataloader.jl
@@ -215,6 +215,21 @@
         dloader = DataLoader(1:1000; batchsize = 2, shuffle = true)
         @test copy(Map(x -> x[1]), Vector{Int}, dloader) != collect(1:2:1000)
     end
+
+    @testset "collate function" begin
+        function collate_fn(batch)
+            # collate observations into a custom batch
+            return hcat([x[1] for x in batch]...), join([x[2] for x in batch])
+        end
+
+        loader = DataLoader((rand(10, 4), ["a", "b", "c", "d"]), batchsize=2, collate=collate_fn)
+        for (x, y) in loader
+            @test size(x) == (10, 2)
+            @test y isa String
+        end
+
+        @test first(loader)[2] == "ab"
+    end
     
     if VERSION > v"1.10"
         @testset "printing" begin

--- a/test/dataloader.jl
+++ b/test/dataloader.jl
@@ -231,6 +231,34 @@
         @test first(loader)[2] == "ab"
     end
     
+    @testset "mapobs" begin
+        X = ones(3, 6)
+
+        function f_mapobs(x)
+            return sum(x[1])
+        end
+
+        d = DataLoader(X, batchsize=2, collate=false);
+
+        d = mapobs(f_mapobs, d);
+
+        for x in d
+            @test x == 3
+        end
+
+        d2 = DataLoader(X, batchsize=2, collate=true);
+
+        function f2_mapobs(x)
+            return sum(x)
+        end
+
+        d2 = mapobs(f2_mapobs, d2);
+
+        for x in d2
+           @test x == 6
+        end
+    end
+
     if VERSION > v"1.10"
         @testset "printing" begin
             X2 = reshape(Float32[1:10;], (2, 5))

--- a/test/eachobs.jl
+++ b/test/eachobs.jl
@@ -11,7 +11,7 @@
     for (i,x) in enumerate(eachobs(X, buffer=b))
         @test x == X[:,i]
     end
-    @test_broken b == X[:,end]
+    @test b == X[:,end]
 
     @testset "batched" begin
         for (i, x) in enumerate(eachobs(X, batchsize=2, partial=true))

--- a/test/eachobs.jl
+++ b/test/eachobs.jl
@@ -7,11 +7,11 @@
         @test x == X[:,i]
     end
 
-    b = zeros(size(X, 1))
-    for (i,x) in enumerate(eachobs(X, buffer=b))
-        @test x == X[:,i]
-    end
-    @test_broken b == X[:,end]
+    # b = zeros(size(X, 1))
+    # for (i,x) in enumerate(eachobs(X, buffer=b))
+    #     @test x == X[:,i]
+    # end
+    # @test_broken b == X[:,end]
 
     @testset "batched" begin
         for (i, x) in enumerate(eachobs(X, batchsize=2, partial=true))

--- a/test/eachobs.jl
+++ b/test/eachobs.jl
@@ -7,11 +7,11 @@
         @test x == X[:,i]
     end
 
-    # b = zeros(size(X, 1))
-    # for (i,x) in enumerate(eachobs(X, buffer=b))
-    #     @test x == X[:,i]
-    # end
-    # @test_broken b == X[:,end]
+    b = zeros(size(X, 1))
+    for (i,x) in enumerate(eachobs(X, buffer=b))
+        @test x == X[:,i]
+    end
+    @test_broken b == X[:,end]
 
     @testset "batched" begin
         for (i, x) in enumerate(eachobs(X, batchsize=2, partial=true))


### PR DESCRIPTION
- Allow to pass a function to the `collate` argument in the DataLoader
- Extend mapobs, normally requiring an indexable container, to `mapobs(f, d::DataLoader)` (close #153)
- Fix passing an array `buffer` to the `DataLoader` constructor.