### PR TITLE
Fix regression with building empty dataloaders

### DIFF
--- a/src/obsview.jl
+++ b/src/obsview.jl
@@ -136,8 +136,10 @@ struct ObsView{Tdata, I<:Union{Int,AbstractVector}} <: AbstractDataContainer
     indices::I
 
     function ObsView(data::T, indices::I) where {T,I}
-        1 <= minimum(indices) || throw(BoundsError(data, indices))
-        maximum(indices) <= numobs(data) || throw(BoundsError(data, indices))
+        if !isempty(indices)
+            1 <= minimum(indices) || throw(BoundsError(data, indices))
+            maximum(indices) <= numobs(data) || throw(BoundsError(data, indices))
+        end
         return new{T,I}(data, indices)
     end
 end

--- a/test/dataloader.jl
+++ b/test/dataloader.jl
@@ -356,3 +356,8 @@ end
         end
     end
 end
+
+@testset "Empty handling" begin
+    xtrain = Matrix{Float64}(undef, 3, 0)
+    data = DataLoader(xtrain, batchsize = 0, partial = true);
+end


### PR DESCRIPTION
One of the obsview changes seems to have broken downstream workflows, where empty DataLoaders used to be accepted but now they error. This reverts back to the previous behavior in this edge case as it's relied upon in some libraries for handling the case of test/train splits of 0% and 100% while being stable.

Found in https://github.com/SciML/ModelingToolkit.jl/actions/runs/13965380427/job/39094470015
