### PR TITLE
Update example in folds.jl

### DIFF
--- a/src/folds.jl
+++ b/src/folds.jl
@@ -123,7 +123,7 @@ validation subsets respectively. Each validation subset will have
 either `size` or `size+1` observations assigned to it. The
 following code snippet generates the index-vectors for `size = 2`.
 
-```julia
+```julia-repl
 julia> train_idx, val_idx = leavepout(10, 2);
 ```
 
@@ -133,9 +133,9 @@ reproduces the full range `1:n`. Note that there is no random
 assignment of observations to subsets, which means that adjacent
 observations are likely to be part of the same validation subset.
 
-```julia
+```julia-repl
 julia> train_idx
-5-element Array{Array{Int64,1},1}:
+5-element Vector{Vector{Int64}}:
  [3,4,5,6,7,8,9,10]
  [1,2,5,6,7,8,9,10]
  [1,2,3,4,7,8,9,10]
@@ -143,7 +143,7 @@ julia> train_idx
  [1,2,3,4,5,6,7,8]
 
 julia> val_idx
-5-element Array{UnitRange{Int64},1}:
+5-element Vector{UnitRange{Int64}}:
  1:2
  3:4
  5:6


### PR DESCRIPTION
Update language tags for syntax highlighting (`julia` -> `julia-repl`) and update `Array` type names to match newer Julia