### PR TITLE
Remove setdiff in kfolds

### DIFF
--- a/src/folds.jl
+++ b/src/folds.jl
@@ -37,23 +37,23 @@ julia> val_idx
  9:10
 ```
 """
-function kfolds(n::Integer, k::Integer = 5)
+function kfolds(n::Integer, k::Integer=5)
     2 <= k <= n || throw(ArgumentError("n must be positive and k must to be within 2:$(max(2,n))"))
     # Compute the size of each fold. This is important because
     # in general the number of total observations might not be
     # divisible by k. In such cases it is custom that the remaining
     # observations are divided among the folds. Thus some folds
     # have one more observation than others.
-    sizes = fill(floor(Int, n/k), k)
-    for i = 1:(n % k)
+    sizes = fill(floor(Int, n / k), k)
+    for i = 1:(n%k)
         sizes[i] = sizes[i] + 1
     end
     # Compute start offset for each fold
     offsets = cumsum(sizes) .- sizes .+ 1
     # Compute the validation indices using the offsets and sizes
-    val_indices = map((o,s) -> (o:o+s-1), offsets, sizes)
+    val_indices = map((o, s) -> (o:o+s-1), offsets, sizes)
     # The train indices are then the indicies not in validation
-    train_indices = map(idx -> setdiff(1:n, idx), val_indices)
+    train_indices = map((o, s) -> vcat(1:o-1, o+s:n), offsets, sizes)
     # We return a tuple of arrays
     return train_indices, val_indices
 end
@@ -106,8 +106,8 @@ function kfolds(data, k::Integer)
     n = numobs(data)
     train_indices, val_indices = kfolds(n, k)
 
-    ((obsview(data, itrain), obsview(data, ival)) 
-        for (itrain, ival) in zip(train_indices, val_indices))
+    ((obsview(data, itrain), obsview(data, ival))
+     for (itrain, ival) in zip(train_indices, val_indices))
 end
 
 kfolds(data; k) = kfolds(data, k)
@@ -151,8 +151,8 @@ julia> val_idx
  9:10
 ```
 """
-function leavepout(n::Integer, p::Integer = 1)
-    1 <= p <= floor(n/2) || throw(ArgumentError("p must to be within 1:$(floor(Int,n/2))"))
+function leavepout(n::Integer, p::Integer=1)
+    1 <= p <= floor(n / 2) || throw(ArgumentError("p must to be within 1:$(floor(Int,n/2))"))
     k = floor(Int, n / p)
     kfolds(n, k)
 end
@@ -181,7 +181,7 @@ See[`kfolds`](@ref) for a related function.
 """
 function leavepout(data, p::Integer)
     n = numobs(data)
-    1 <= p <= floor(n/2) || throw(ArgumentError("p must to be within 1:$(floor(Int,n/2))"))
+    1 <= p <= floor(n / 2) || throw(ArgumentError("p must to be within 1:$(floor(Int,n/2))"))
     k = floor(Int, n / p)
     kfolds(data, k)
 end


### PR DESCRIPTION
Rather than using `setdiff` to compute training indices (which can allocate large vectors on big datasets), compute them analytically from fold sizes and offsets. This reduces memory usage and improves performance.

kfolds **with** `setdiff`
```julia
julia> @benchmark kfolds(Int(1e5), 5) seconds = 600
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  22.937 ms … 272.079 ms  ┊ GC (min … max): 0.00% … 80.58%
 Time  (median):     25.023 ms               ┊ GC (median):    3.32%
 Time  (mean ± σ):   26.898 ms ±   9.199 ms  ┊ GC (mean ± σ):  5.33% ±  5.44%

  ▃▄█▇▆▆▅▄▄▄▄▃▂▂▂▁▁▁▁                                          ▂
  ████████████████████████▇▇▇▇▆▆▆▅▆▆▆▄▆▆▅▅▅▆▄▆▆▅▁▅▅▅▅▁▅▄▅▃▃▄▅▄ █
  22.9 ms       Histogram: log(frequency) by time      57.2 ms <

 Memory estimate: 20.39 MiB, allocs estimate: 130.
````

kfolds **without** `setdiff`
```julia
julia> @benchmark kfolds(Int(1e5), 5) seconds = 600
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  235.259 μs …   7.080 ms  ┊ GC (min … max):  0.00% … 88.45%
 Time  (median):     335.147 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   454.221 μs ± 296.795 μs  ┊ GC (mean ± σ):  15.21% ± 17.02%

     ▆█▇▅▃▃▂▂▂▂▁                                ▁▁▁ ▁           ▁
  ▂▂███████████████▇█▇▆▆▆▆▇▆▆▄▅▆▇▅▆▇▇▇▇▇▇▇████████████▇▇▇▇▇▇▇▇▆ █
  235 μs        Histogram: log(frequency) by time       1.43 ms <

 Memory estimate: 3.05 MiB, allocs estimate: 25.
```