### PR TITLE
Replace FLoops with manual Threads.@spawn

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,26 +18,21 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'min'
           - '1'
           - 'nightly'
         os:
           - ubuntu-latest
-        arch:
-          - x64
         include:
           - os: windows-latest
             version: '1'
-            arch: x64
           - os: macOS-latest
             version: '1'
-            arch: x64
     steps:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,13 @@
 name = "MLUtils"
 uuid = "f1d291b0-491e-4a28-83b9-f70985020b54"
 authors = ["Carlo Lucibello <carlo.lucibello@gmail.com> and contributors"]
-version = "0.4.9"
+version = "0.4.10"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
 MLCore = "c2834f40-e789-41da-a90e-33b280584a8c"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -17,14 +16,18 @@ SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[weakdeps]
 Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
+
+[extensions]
+TransducersExt = "Transducers"
 
 [compat]
 ChainRulesCore = "1.0"
 Compat = "4.2"
 DataAPI = "1.0"
 DelimitedFiles = "1.0"
-FLoops = "0.2"
 MLCore = "1.0.0"
 NNlib = "0.8, 0.9"
 ShowCases = "0.1"
@@ -33,4 +36,4 @@ Statistics = "1"
 StatsBase = "0.33, 0.34"
 Tables = "1.10"
 Transducers = "0.4"
-julia = "1.6"
+julia = "1.10"

--- a/ext/TransducersExt.jl
+++ b/ext/TransducersExt.jl
@@ -1,0 +1,46 @@
+module TransducersExt
+
+using MLUtils: DataLoader, numobs, getobs, getobs!, _shuffledata
+import Transducers
+
+@inline function _dataloader_foldl1(rf, val, d::DataLoader, data)
+    if d.shuffle
+        return _dataloader_foldl2(rf, val, d, _shuffledata(d.rng, data))
+    else
+        return _dataloader_foldl2(rf, val, d, data)
+    end
+end
+
+@inline function _dataloader_foldl2(rf, val, d::DataLoader, data)
+    if d.buffer == false
+        return _dataloader_foldl3(rf, val, data)
+    else
+        return _dataloader_foldl3_buffered(rf, val, data, d.buffer)
+    end
+end
+
+@inline function _dataloader_foldl3(rf, val, data)
+    for i in 1:numobs(data)
+        @inbounds x = getobs(data, i)
+        # TODO: in 1.8 we could @inline this at the callsite,
+        #       optimizer seems to be very sensitive to inlining and
+        #       quite brittle in its capacity to keep this type stable
+        val = Transducers.@next(rf, val, x)
+    end
+    return Transducers.complete(rf, val)
+end
+
+@inline function _dataloader_foldl3_buffered(rf, val, data, buf)
+    for i in 1:numobs(data)
+        @inbounds x = getobs!(buf, data, i)
+        val = Transducers.@next(rf, val, x)
+    end
+    return Transducers.complete(rf, val)
+end
+
+@inline function Transducers.__foldl__(rf, val, d::DataLoader)
+    d.parallel && throw(ArgumentError("Transducer fold protocol not supported on parallel data loads"))
+    return _dataloader_foldl1(rf, val, d, d._data)
+end
+
+end # module

--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -3,10 +3,7 @@ module MLUtils
 using Random
 using Statistics
 using ShowCases: ShowLimit
-using FLoops: @floop
-using FLoops.Transducers: Executor, ThreadedEx
 import StatsBase: sample
-using Transducers
 using Tables
 using DataAPI
 using Base: @propagate_inbounds

--- a/src/dataloader.jl
+++ b/src/dataloader.jl
@@ -195,7 +195,7 @@ end
 function Base.iterate(d::DataLoader{T,B,:parallel}) where {T,B}
     @assert d.buffer != false
     data = d.shuffle ? _shuffledata(d.rng, d._data) : d._data
-    iter = _eachobsparallel_buffered(d.buffer, data)
+    iter = _eachobsparallel_buffered(d.buffer, data; channelsize=Threads.nthreads())
     obs, state = iterate(iter)
     return obs, (iter, state)
 end
@@ -213,7 +213,7 @@ end
 function Base.iterate(d::DataLoader{T,Bool,:parallel}) where {T}
     @assert d.buffer == false
     data = d.shuffle ? _shuffledata(d.rng, d._data) : d._data
-    iter = _eachobsparallel_unbuffered(data)
+    iter = _eachobsparallel_unbuffered(data; channelsize=Threads.nthreads())
     obs, state = iterate(iter)
     return obs, (iter, state)
 end
@@ -357,48 +357,4 @@ end
 function _expanded_summary(xs::NamedTuple)
   parts = ["$k = "*_expanded_summary(x) for (k,x) in zip(keys(xs), xs)]
   "(; " * join(parts, ", ") * ")"
-end
-
-
-### TRANSDUCERS IMPLEMENTATION #############################
-
-
-@inline function _dataloader_foldl1(rf, val, d::DataLoader, data)
-    if d.shuffle
-        return _dataloader_foldl2(rf, val, d, _shuffledata(d.rng, data))
-    else
-        return _dataloader_foldl2(rf, val, d, data)
-    end
-end
-
-@inline function _dataloader_foldl2(rf, val, d::DataLoader, data)
-    if d.buffer == false
-        return _dataloader_foldl3(rf, val, data)
-    else
-        return _dataloader_foldl3_buffered(rf, val, data, d.buffer)
-    end
-end
-
-@inline function _dataloader_foldl3(rf, val, data)
-    for i in 1:numobs(data)
-        @inbounds x = getobs(data, i)
-        # TODO: in 1.8 we could @inline this at the callsite,
-        #       optimizer seems to be very sensitive to inlining and
-        #       quite brittle in its capacity to keep this type stable
-        val = Transducers.@next(rf, val, x)
-    end
-    return Transducers.complete(rf, val)
-end
-
-@inline function _dataloader_foldl3_buffered(rf, val, data, buf)
-    for i in 1:numobs(data)
-        @inbounds x = getobs!(buf, data, i)
-        val = Transducers.@next(rf, val, x)
-    end
-    return Transducers.complete(rf, val)
-end
-
-@inline function Transducers.__foldl__(rf, val, d::DataLoader)
-    d.parallel && throw(ArgumentError("Transducer fold protocol not supported on parallel data loads"))
-    return _dataloader_foldl1(rf, val, d, d._data)
 end

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -1,5 +1,5 @@
 # """
-#     eachobsparallel(data; buffer, executor, channelsize)
+#     eachobsparallel(data; buffer, channelsize, basesize)
 
 # Construct a data iterator over observations in container `data`.
 # It uses available threads as workers to load observations in
@@ -19,30 +19,25 @@
 #     `data`. Setting `buffer = true` means that when using the iterator, an
 #     observation is only valid for the current loop iteration.
 #     You can also pass in a preallocated `buffer = getobs(data, 1)`.
-# - `executor = Folds.ThreadedEx()`: task scheduler
-#     You may specify a different task scheduler which can
-#     be any `Folds.Executor`.
 # - `channelsize = Threads.nthreads()`: the number of observations that are prefetched.
 #     Increasing `channelsize` can lead to speedups when per-observation processing
 #     time is irregular but will cause higher memory usage.
 # """
 function eachobsparallel(
         data;
-        executor::Executor = _default_executor(),
         buffer::Bool = false,
-        channelsize = Threads.nthreads())
-    if buffer == false
-        return _eachobsparallel_unbuffered(data, executor; channelsize)
+        channelsize::Int = Threads.nthreads())
+    if buffer
+        return _eachobsparallel_buffered(buffer, data; channelsize)
     else
-        return _eachobsparallel_buffered(buffer, data, executor; channelsize)
+        return _eachobsparallel_unbuffered(data; channelsize)
     end
 end
 
 function _eachobsparallel_buffered(
         buffer,
-        data,
-        executor = _default_executor();
-        channelsize=Threads.nthreads())
+        data;
+        channelsize::Int)
     buffers = [buffer]
     foreach(_ -> push!(buffers, deepcopy(buffer)), 1:channelsize)
 
@@ -52,7 +47,7 @@ function _eachobsparallel_buffered(
     # each iteration.
     setup_channel(sz) = RingBuffer(buffers)
 
-    return Loader(1:numobs(data); executor, channelsize, setup_channel) do ringbuffer, i
+    return Loader(1:numobs(data); channelsize, setup_channel) do ringbuffer, i
         # Internally, `RingBuffer` will `put!` the result in the results channel
         put!(ringbuffer) do buf
             getobs!(buf, data, i)
@@ -60,23 +55,14 @@ function _eachobsparallel_buffered(
     end
 end
 
-function _eachobsparallel_unbuffered(data, 
-        executor = _default_executor(); 
-        channelsize=Threads.nthreads()
+function _eachobsparallel_unbuffered(data;
+        channelsize::Int
     )
-
-    return Loader(1:numobs(data); executor, channelsize) do ch, i
+    return Loader(1:numobs(data); channelsize) do ch, i
         obs = getobs(data, i)
         put!(ch, obs)
     end
 end
-
-
-# Unlike DataLoaders.jl, this currently does not use task pools
-# since  `ThreadedEx` has shown to be more performant. This may
-# change in the future.
-# See PR 33 https://github.com/JuliaML/MLUtils.jl/pull/33
-_default_executor() = ThreadedEx()
 
 
 # ## Internals
@@ -86,18 +72,16 @@ _default_executor() = ThreadedEx()
 
 
 # """
-#     Loader(f, args; executor, channelsize, setup_channel)
+#     Loader(f, args; channelsize, setup_channel)
 
 # Create a threaded iterator that iterates over `(f(arg) for arg in args)`
 # using threads that prefill a channel of length `channelsize`.
 
-# Note: results may not be returned in the correct order, depending on
-# `executor`.
+# Note: results may not be returned in the correct order.
 # """
 struct Loader
     f
     argiter::AbstractVector
-    executor::Executor
     channelsize::Int
     setup_channel
 end
@@ -105,10 +89,9 @@ end
 function Loader(
         f,
         argiter;
-        executor=_default_executor(),
-        channelsize=Threads.nthreads(),
+        channelsize::Int = Threads.nthreads(),
         setup_channel = sz -> Channel(sz))
-    Loader(f, argiter, executor, channelsize, setup_channel)
+    Loader(f, argiter, channelsize, setup_channel)
 end
 
 Base.length(loader::Loader) = length(loader.argiter)
@@ -121,18 +104,37 @@ end
 
 function Base.iterate(loader::Loader)
     ch = loader.setup_channel(loader.channelsize)
-    task = @async begin
-        @floop loader.executor for arg in loader.argiter
-            try
-                loader.f(ch, arg)
-            catch e
-                close(ch, e)
-                rethrow()
-            end
+    basesize = length(loader.argiter) ÷ Threads.nthreads()
+    task = Threads.@spawn begin
+        try
+            _spawn_foreach(loader.f, ch, loader.argiter,
+                           firstindex(loader.argiter),
+                           lastindex(loader.argiter),
+                           basesize)
+        catch e
+            close(ch, e)
+            rethrow()
         end
     end
 
     return Base.iterate(loader, LoaderState(task, ch, length(loader.argiter)))
+end
+
+# Recursive divide-and-conquer over `argiter[lo:hi]`:
+# At each level we `@spawn` the right half and recurse on the left half on the current task, then `wait` on the right.
+# Leaves of size `<= basesize` are processed sequentially.
+function _spawn_foreach(f::F, ch, argiter, lo, hi, basesize::Int) where {F}
+    if hi - lo < max(basesize, 1)
+        for i in lo:hi
+            f(ch, argiter[i])
+        end
+    else
+        mid = (lo + hi) >> 1
+        task = Threads.@spawn _spawn_foreach($f, $ch, $argiter, $(mid + 1), $hi, $basesize)
+        _spawn_foreach(f, ch, argiter, lo, mid, basesize)
+        wait(task)
+    end
+    return nothing
 end
 
 function Base.iterate(::Loader, state::LoaderState)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,10 +1,8 @@
 [deps]
-BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
 MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -7,14 +7,6 @@
         @test all(x ∈ 1:10 for x in X_)
         @test length(unique(X_)) == 10
     end
-
-    @testset "With `ThreadedEx`" begin
-        iter = eachobsparallel(collect(1:10); executor = ThreadedEx())
-        @test_nowarn for i in iter end
-        X_ = collect(iter)
-        @test all(x ∈ 1:10 for x in X_)
-        @test length(unique(X_)) == 10
-    end
 end
 
 


### PR DESCRIPTION
## Motivation

`FLoops.jl` and `Transducers.jl` are both registered out of the [JuliaFolds2](https://github.com/JuliaFolds2) organization, which forked the original [JuliaFolds](https://github.com/JuliaFolds) packages after upstream went silent (see [JuliaFolds2/Transducers.jl#31](https://github.com/JuliaFolds2/Transducers.jl/issues/31), the issue that motivated the fork). The forks are alive but very low-velocity: `JuliaFolds2/FLoops.jl` has had 14 commits in 2025 (almost entirely automated CompatHelper / pkg-update PRs), and `JuliaFolds2/Transducers.jl` has had 1 commit in 2025 (housekeeping — drop Julia <1.10, remove Requires).

Removing this part of the stack from `MLUtils` has been on the radar for a while:

- [#175 "Floops depedency should be removed"](https://github.com/JuliaML/MLUtils.jl/issues/175) (March 2024) explicitly considered `OhMyThreads` as a replacement.
- [#155 "MLUtils seems quite heavy"](https://github.com/JuliaML/MLUtils.jl/issues/155) (May 2023) flagged the broader weight concern.

Other packages in the ecosystem have made the same call: AbstractMCMC.jl removed `Transducers` as a hard dep in [TuringLang/AbstractMCMC.jl#201](https://github.com/TuringLang/AbstractMCMC.jl/pull/201) (merged April 2026), citing 11 transitive dependencies eliminated.

In a fresh environment with this branch's `MLUtils` installed (61 packages resolved), adding `FLoops` brings the total to **85 packages — 24 added** (about 20 non-stdlib): `FLoops`, `FLoopsBase`, `Transducers`, `MLStyle`, `JuliaVariables`, `NameResolution`, `Setfield`, `ContextVariablesX`, `Accessors`, `BangBang`, `MicroCollections`, `SplittablesBase`, `InitialValues`, `DefineSingletons`, `Baselet`, `CompositionsBase`, `ConstructionBase`, `ArgCheck`, `PrettyPrint`, `InverseFunctions`, plus a handful of stdlibs that `Transducers` pulls. Some of these may well already be loaded for other reasons in any given user's project, but they are not currently shared with anything else `MLUtils` depends on.

## Approach

Replace `FLoops.@floop ThreadedEx() for arg in argiter` in `Loader` with a recursive divide-and-conquer using `Threads.@spawn` directly. The structure mirrors `Transducers._reduce`: at each level the right half is `@spawn`'d, the left half recurses on the current task, then `wait` on the right. `basesize = length ÷ Threads.nthreads()` matches the `Transducers.ThreadedEx` default; the base-case predicate uses `max(basesize, 1)` (also lifted from Transducers) so that `numobs < nthreads` cases terminate.

The outer dispatcher uses `Threads.@spawn` rather than `@async` to avoid making the *calling* task non-migratable for the lifetime of the iteration, per the warning in the [`@async` docstring](https://docs.julialang.org/en/v1/base/parallel/#Base.@async) about library code.

`basesize` is currently computed inline. If there's interest, it could be exposed (as a kwarg on `eachobsparallel` / `DataLoader`) in a follow-up so users can tune task granularity per call without a major API change.

Also moves `Transducers` from a required dep to a weakdep + extension (`ext/TransducersExt.jl`), and bumps the minimum Julia version to 1.10 (needed for weakdeps; CI matrix updated to `min-patch`).

## Alternatives considered

- **`OhMyThreads.jl`** — the alternative explicitly raised in #175. More actively maintained, drop-in for the parallel dispatch, but its default chunking strategy differs from FLoops/Transducers — see the OhMyThreads column in the table below: `TimeDataset n=10000, t=1e-3` goes from `3.06 s` (master) to `4.31 s`. Recovering parity needs explicit tuning of the number of tasks (`chunking=false` brings it to `2.85 s`, but spawns one task per observation, which is its own footgun for large `numobs`). Going with manual `Threads.@spawn` keeps exactly the algorithm that was running underneath FLoops, i.e. characteristics don't change for users.
- **Keep `FLoops`, narrow the surface area** — doesn't address the dependency-footprint or maintenance velocity concerns.

## Benchmarks

Julia 1.12.6, 6 threads. Single trials; ~10% run-to-run variance on the `TimeDataset` rows.

| Benchmark | master (FLoops) | This PR | OhMyThreads default (for ref.) |
|---|---|---|---|
| TimeDataset n=100, t=0.1 | 1.37 s | **1.33 s** | 1.79 s |
| TimeDataset n=10000, t=1e-3 | 3.06 s | **2.84 s** | 4.31 s |
| TimeDataset n=10000, t=1e-4 | 3.12 s | **2.85 s** | 4.40 s |
| TimeDataset n=10000, t=1e-5 | 3.17 s | **2.85 s** | 4.48 s |
| CPUDataset n=1000, w=64 | 0.081 s | 0.117 s | 0.078 s |
| CPUDataset n=1000, w=256 | 0.201 s | 0.182 s | 0.163 s |
| ArrayDataset, buffer=true | 0.241 s | **0.106 s** | 0.141 s |
| TimeDataset bs=8 | 0.345 s | 0.355 s | 0.459 s |
| CPUDataset bs=8 | 0.033 s | 0.088 s | 0.027 s |

Net: TimeDataset (representative of I/O-bound `getobs`) is consistently slightly faster than master and substantially better than OhMyThreads at default settings. The CPU-bound `CPUDataset bs=8` row is dominated by `@spawn` setup cost on a tiny total workload (63 batches of small matmul), so single-trial variance is high.

<details>
<summary>Benchmark script</summary>

```julia
using MLUtils
using MLUtils: eachobsparallel
using Random

struct TimeDataset
    n::Int
    t::Float64
end
MLUtils.numobs(d::TimeDataset) = d.n
MLUtils.getobs(d::TimeDataset, i::Integer) = (sleep(d.t); i)
MLUtils.getobs(d::TimeDataset, idxs::AbstractVector) = [getobs(d, i) for i in idxs]

struct CPUDataset
    n::Int
    work::Int
end
MLUtils.numobs(d::CPUDataset) = d.n
MLUtils.getobs(d::CPUDataset, i::Integer) = sum(rand(d.work, d.work) * rand(d.work))
MLUtils.getobs(d::CPUDataset, idxs::AbstractVector) = [getobs(d, i) for i in idxs]

struct ArrayDataset
    n::Int
    sz::Tuple{Int,Int}
end
MLUtils.numobs(d::ArrayDataset) = d.n
MLUtils.getobs(d::ArrayDataset, i::Integer) = rand!(Array{Float64}(undef, d.sz...))
MLUtils.getobs!(buf, d::ArrayDataset, i::Integer) = rand!(buf)

# warmup
for _ in eachobsparallel(TimeDataset(10, 0.001)) end

println("Threads: ", Threads.nthreads(), "  Julia: ", VERSION)

println("\n# eachobsparallel — TimeDataset (sleep per obs)")
for (n, t) in [(100, 0.1), (10_000, 1e-3), (10_000, 1e-4), (10_000, 1e-5)]
    data = TimeDataset(n, t)
    e = @elapsed for _ in eachobsparallel(data) end
    println("  n=$n, t=$t: ", e, " s")
end

println("\n# eachobsparallel — CPUDataset (matmul per obs)")
for (n, w) in [(1000, 64), (1000, 256)]
    data = CPUDataset(n, w)
    e = @elapsed for _ in eachobsparallel(data) end
    println("  n=$n, work=$w: ", e, " s")
end

println("\n# DataLoader(buffer=true, parallel=true) — ArrayDataset")
let data = ArrayDataset(1000, (64, 64))
    e = @elapsed for _ in DataLoader(data; buffer=true, parallel=true, batchsize=-1) end
    println("  n=1000, sz=(64,64): ", e, " s")
end

println("\n# DataLoader(batchsize=8, parallel=true)")
let data = TimeDataset(1000, 1e-3)
    e = @elapsed for _ in DataLoader(data; batchsize=8, parallel=true) end
    println("  TimeDataset(1000, 1e-3), bs=8: ", e, " s")
end
let data = CPUDataset(500, 128)
    e = @elapsed for _ in DataLoader(data; batchsize=8, parallel=true) end
    println("  CPUDataset(500, 128), bs=8: ", e, " s")
end
```

</details>

<details>
<summary>Raw outputs (master, this PR, OhMyThreads default)</summary>

`master` (FLoops):

```
Threads: 6  Julia: 1.12.6

# eachobsparallel — TimeDataset (sleep per obs)
  n=100, t=0.1: 1.368496292 s
  n=10000, t=0.001: 3.059648 s
  n=10000, t=0.0001: 3.116711292 s
  n=10000, t=1.0e-5: 3.171029166 s

# eachobsparallel — CPUDataset (matmul per obs)
  n=1000, work=64: 0.080803167 s
  n=1000, work=256: 0.201418208 s

# DataLoader(buffer=true, parallel=true) — ArrayDataset
  n=1000, sz=(64,64): 0.240511958 s

# DataLoader(batchsize=8, parallel=true)
  TimeDataset(1000, 1e-3), bs=8: 0.345019208 s
  CPUDataset(500, 128), bs=8: 0.032582959 s
```

This PR (manual `Threads.@spawn`):

```
Threads: 6  Julia: 1.12.6

# eachobsparallel — TimeDataset (sleep per obs)
  n=100, t=0.1: 1.331942625 s
  n=10000, t=0.001: 2.83705325 s
  n=10000, t=0.0001: 2.853143958 s
  n=10000, t=1.0e-5: 2.848424875 s

# eachobsparallel — CPUDataset (matmul per obs)
  n=1000, work=64: 0.116775375 s
  n=1000, work=256: 0.1815135 s

# DataLoader(buffer=true, parallel=true) — ArrayDataset
  n=1000, sz=(64,64): 0.105989542 s

# DataLoader(batchsize=8, parallel=true)
  TimeDataset(1000, 1e-3), bs=8: 0.355370292 s
  CPUDataset(500, 128), bs=8: 0.087745334 s
```

Earlier experiment with `OhMyThreads.tforeach` at default chunking, for reference:

```
Threads: 6  Julia: 1.12.6

# eachobsparallel — TimeDataset (sleep per obs)
  n=100, t=0.1: 1.788332125 s
  n=10000, t=0.001: 4.311297167 s
  n=10000, t=0.0001: 4.399013791 s
  n=10000, t=1.0e-5: 4.481137083 s

# eachobsparallel — CPUDataset (matmul per obs)
  n=1000, work=64: 0.078201542 s
  n=1000, work=256: 0.162779042 s

# DataLoader(buffer=true, parallel=true) — ArrayDataset
  n=1000, sz=(64,64): 0.141071958 s

# DataLoader(batchsize=8, parallel=true)
  TimeDataset(1000, 1e-3), bs=8: 0.458739833 s
  CPUDataset(500, 128), bs=8: 0.027184666 s
```

</details>

## Test plan

- [x] `julia --project -t auto -e 'using Pkg; Pkg.test()'` — full suite passes
- [x] `eachobsparallel` testset green (9/9)
- [x] Smoke test for `numobs < nthreads` (`n = 0, 1, 3, 5` with 6 threads) — all terminate and produce the expected items
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)