### PR TITLE
Add gradient tests for unsqueeze and unstack

### DIFF
--- a/test/utils.jl
+++ b/test/utils.jl
@@ -8,6 +8,11 @@
     @test unsqueeze(dims=2)(x) == unsqueeze(x, dims=2)
 
     @test_throws AssertionError unsqueeze(rand(2,2), dims=4)
+
+    # test gradient
+    for d in (1, 2, 3, 4)
+        test_zygote(unsqueeze, x, fkwargs=(; dims=d), check_inferred=false)
+    end
 end
 
 @testset "stack and unstack" begin
@@ -25,6 +30,11 @@ end
 
     for d in (1,2,3)
         test_zygote(stack, [x,2x], fkwargs=(; dims=d), check_inferred=false)
+    end
+
+    # test gradient of unstack
+    for d in (1,2)
+        test_zygote(unstack, x, fkwargs=(; dims=d), check_inferred=false)
     end
 
     # Issue #121


### PR DESCRIPTION
Adds Zygote gradient tests for `unsqueeze` and `unstack`, completing the remaining boxes in #51 (`stack` already had a gradient test).

- `unsqueeze`: tested across all valid `dims` (1–4) on a 3D array
- `unstack`: tested across `dims` 1 and 2 on a matrix

Both pass via `test_zygote`/`test_rrule` (finite-difference primal + pullback comparison). No source changes were needed — both functions are already differentiable through generic AD.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)