### PR TITLE
Add timeseries_kfolds for time-series cross-validation

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -47,6 +47,7 @@ slidingwindow
 ```@docs
 leavepout
 kfolds
+timeseries_kfolds
 splitobs
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,7 +15,7 @@
 - Resampling procedures (`undersample` and `oversample`).
 - Train/test splits (`splitobs`, stratified split) 
 - Data partitioning and aggregation tools (`batch`, `batch_sequence`, `unbatch`, `chunk`, `group_counts`, `group_indices`).
-- Folds for cross-validation (`kfolds`, `leavepout`).
+- Folds for cross-validation (`kfolds`, `leavepout`, `timeseries_kfolds`).
 - Datasets lazy tranformations (`mapobs`, `filterobs`, `groupobs`, `joinobs`, `shuffleobs`).
 - Toy datasets for demonstration purpose. 
 - Other data handling utilities (`flatten`, `normalise`, `unsqueeze`, `stack`, `unstack`, `slidingwindow`).

--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -52,7 +52,8 @@ include("parallel.jl")
 
 include("folds.jl")
 export kfolds,
-       leavepout
+       leavepout,
+       timeseries_kfolds
 
 include("randobs.jl")
 export randobs

--- a/src/folds.jl
+++ b/src/folds.jl
@@ -187,3 +187,95 @@ function leavepout(data, p::Integer)
 end
 
 leavepout(data; p::Integer=1) = leavepout(data, p)
+
+"""
+    timeseries_kfolds(n::Integer; k=5, gap=0, max_train_size=nothing) -> Tuple
+
+Compute the train/validation assignments for `k` time-ordered folds of `n`
+observations, and return them in the form of two vectors of index ranges. The
+first vector contains the training ranges and the second the validation ranges.
+
+Unlike [`kfolds`](@ref), the validation block of each fold always comes *after*
+its training block, so temporal order is respected. This is the equivalent of
+scikit-learn's `TimeSeriesSplit` and MLJ's `TimeSeriesCV`.
+
+The last `k * (n ÷ (k+1))` observations are split into `k` contiguous validation
+blocks; the training set for each fold is, by default, all earlier observations
+(an expanding window). Any observations left over from the non-even division are
+absorbed into the first training block.
+
+# Keyword arguments
+- `k`: number of folds (default `5`).
+- `gap`: number of observations to discard between each training block and its
+  validation block (default `0`).
+- `max_train_size`: if given, cap each training window to this many of the most
+  recent observations (a sliding window instead of an expanding one).
+
+# Examples
+
+```jldoctest
+julia> train_idx, val_idx = timeseries_kfolds(10; k=3);
+
+julia> train_idx
+3-element Vector{UnitRange{Int64}}:
+ 1:4
+ 1:6
+ 1:8
+
+julia> val_idx
+3-element Vector{UnitRange{Int64}}:
+ 5:6
+ 7:8
+ 9:10
+```
+"""
+function timeseries_kfolds(n::Integer; k::Integer=5, gap::Integer=0,
+                           max_train_size::Union{Nothing,Integer}=nothing)
+    2 <= k <= n - 1 || throw(ArgumentError("k must be within 2:$(max(2, n - 1))"))
+    gap >= 0 || throw(ArgumentError("gap must be non-negative"))
+    max_train_size === nothing || max_train_size >= 1 ||
+        throw(ArgumentError("max_train_size must be positive"))
+    fold_size = n ÷ (k + 1)
+    fold_size >= 1 || throw(ArgumentError("not enough observations ($n) for k=$k folds"))
+
+    val_indices = Vector{UnitRange{Int}}(undef, k)
+    train_indices = Vector{UnitRange{Int}}(undef, k)
+    for i in 1:k
+        vstart = n - (k - i + 1) * fold_size + 1
+        vstop = n - (k - i) * fold_size
+        tstop = vstart - 1 - gap
+        tstop >= 1 || throw(ArgumentError("gap=$gap is too large for k=$k folds"))
+        tstart = max_train_size === nothing ? 1 : max(1, tstop - max_train_size + 1)
+        train_indices[i] = tstart:tstop
+        val_indices[i] = vstart:vstop
+    end
+    return train_indices, val_indices
+end
+
+"""
+    timeseries_kfolds(data; k=5, gap=0, max_train_size=nothing)
+
+Repartition a `data` container using a time-series k-folds strategy and return
+the sequence of folds as a lazy iterator. Only data subsets are created, which
+means that no actual data is copied until [`getobs`](@ref) is invoked.
+
+Observations are assumed to be in chronological order, i.e. `getobs(data, i)`
+precedes `getobs(data, i+1)` in time. The data is *not* sorted, and unlike
+[`kfolds`](@ref) it must **not** be shuffled, since that would destroy the
+temporal ordering the folds rely on.
+
+```julia
+for (train, val) in timeseries_kfolds(X; k=10)
+    # the observations in `train` all precede those in `val`
+end
+```
+
+See the integer method [`timeseries_kfolds(n::Integer)`](@ref) for the keyword
+arguments and the precise splitting scheme, and [`kfolds`](@ref) for the
+non-temporal variant.
+"""
+function timeseries_kfolds(data; kws...)
+    train_indices, val_indices = timeseries_kfolds(numobs(data); kws...)
+    ((obsview(data, itrain), obsview(data, ival))
+     for (itrain, ival) in zip(train_indices, val_indices))
+end

--- a/test/folds.jl
+++ b/test/folds.jl
@@ -36,3 +36,41 @@ end
     @test collect(leavepout(1:15, p=5)) == collect(kfolds(1:15, 3))
 end
 
+@testset "timeseries_kfolds" begin
+    @testset "int" begin
+        # matches MLJ's TimeSeriesCV(nfolds=3) on 1:10
+        tr, val = timeseries_kfolds(10; k=3)
+        @test tr == [1:4, 1:6, 1:8]
+        @test val == [5:6, 7:8, 9:10]
+
+        # validation blocks are contiguous, equal-sized, and ordered after train
+        for (itr, iv) in zip(tr, val)
+            @test last(itr) < first(iv)
+        end
+
+        # gap discards observations between train and val
+        @test timeseries_kfolds(10; k=3, gap=1)[1] == [1:3, 1:5, 1:7]
+        @test timeseries_kfolds(10; k=3, gap=1)[2] == [5:6, 7:8, 9:10]
+
+        # max_train_size turns the expanding window into a sliding one
+        @test timeseries_kfolds(10; k=3, max_train_size=2)[1] == [3:4, 5:6, 7:8]
+
+        @test_throws ArgumentError timeseries_kfolds(10; k=1)
+        @test_throws ArgumentError timeseries_kfolds(10; k=10)   # k > n-1
+        @test_throws ArgumentError timeseries_kfolds(3; k=3)     # fold_size == 0
+        @test_throws ArgumentError timeseries_kfolds(10; k=3, gap=10)
+        @test_throws ArgumentError timeseries_kfolds(10; k=3, gap=-1)
+    end
+
+    @testset "data" begin
+        for (xtr, xval) in timeseries_kfolds(1:10; k=3)
+            @test maximum(xtr) < minimum(xval)
+        end
+
+        for ((xtr, ytr), (xval, yval)) in timeseries_kfolds((1:10, 11:20); k=3)
+            @test maximum(xtr) < minimum(xval)
+            @test maximum(ytr) < minimum(yval)
+        end
+    end
+end
+


### PR DESCRIPTION
Closes #58.

Adds `timeseries_kfolds`, an expanding-window time-series cross-validation function — the equivalent of scikit-learn's [`TimeSeriesSplit`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.TimeSeriesSplit.html) and MLJ's `TimeSeriesCV`. Unlike `kfolds`, each fold's validation block always comes *after* its training block, so temporal order is respected.

```julia
julia> train_idx, val_idx = timeseries_kfolds(10; k=3);

julia> train_idx
3-element Vector{UnitRange{Int64}}:
 1:4
 1:6
 1:8

julia> val_idx
3-element Vector{UnitRange{Int64}}:
 5:6
 7:8
 9:10
```

This reproduces MLJ's `TimeSeriesCV(nfolds=3)` on `1:10`.

### Details
- Two methods mirroring `kfolds`/`leavepout`: an integer version returning index ranges, and a data-container version returning a lazy iterator of `obsview`s.
- Keyword arguments:
  - `k`: number of folds (default `5`).
  - `gap`: observations to discard between each training block and its validation block.
  - `max_train_size`: cap each training window to the most recent N observations (sliding instead of expanding window).
- Observations are assumed to be in chronological order (`getobs(data, i)` precedes `getobs(data, i+1)`); the data is not sorted and must not be shuffled. This is documented in the docstring.

### Design notes
Per the discussion in #58, this is deliberately the *simple* index-based version rather than anything with timestamp/temporal-object machinery — it sidesteps the "time dimensions are hard" concern raised in the thread. Implemented as a separate function (not an `ordered=true` keyword on `kfolds`) because the output structure, valid `k` range, and applicable keywords all differ from `kfolds`, matching how scikit-learn and MLJ keep these as distinct types.

### Tests
New testset in `test/folds.jl` covering the index math, `gap`, `max_train_size`, the data-container/multi-arg path, and argument-error cases. Exported in `MLUtils.jl` and added to the API and feature docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)