### PR TITLE
Add rescale (min-max scaling) and improve normalise discoverability

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -77,6 +77,7 @@ flatten
 group_counts
 group_indices
 normalise
+rescale
 rpad_constant
 unbatch
 unsqueeze

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,7 +18,7 @@
 - Folds for cross-validation (`kfolds`, `leavepout`).
 - Datasets lazy tranformations (`mapobs`, `filterobs`, `groupobs`, `joinobs`, `shuffleobs`).
 - Toy datasets for demonstration purpose. 
-- Other data handling utilities (`flatten`, `normalise`, `unsqueeze`, `stack`, `unstack`, `slidingwindow`).
+- Other data handling utilities (`flatten`, `normalise`, `rescale`, `unsqueeze`, `stack`, `unstack`, `slidingwindow`).
 
 
 ## Examples

--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -84,6 +84,7 @@ export chunk,
        ones_like,
        rand_like,
        randn_like,
+       rescale,
        rpad_constant,
        stack, # in Base since julia v1.9
        trues_like,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -400,15 +400,36 @@ end
     normalise(x; dims=ndims(x), ϵ=1e-5)
 
 Normalise the array `x` to mean 0 and standard deviation 1 across the dimension(s) given by `dims`.
-Per default, `dims` is the last dimension. 
+Per default, `dims` is the last dimension.
 
 `ϵ` is a small additive factor added to the denominator for numerical stability.
+
+This operation is also known as *standardization* or *z-score normalization*.
+See also [`rescale`](@ref) for min-max scaling to the `[0, 1]` range.
 """
 function normalise(x::AbstractArray; dims=ndims(x), ϵ=ofeltype(x, 1e-5))
     μ = mean(x, dims=dims)
     #   σ = std(x, dims=dims, mean=μ, corrected=false) # use this when Zygote#478 gets merged
     σ = std(x, dims=dims, corrected=false)
     return (x .- μ) ./ (σ .+ ϵ)
+end
+
+"""
+    rescale(x; dims=ndims(x), ϵ=1e-5)
+
+Rescale the array `x` to the `[0, 1]` range across the dimension(s) given by `dims`,
+by subtracting the minimum and dividing by the range (maximum minus minimum).
+Per default, `dims` is the last dimension.
+
+This operation is also known as *min-max scaling* or *min-max normalization*.
+
+`ϵ` is a small additive factor added to the denominator for numerical stability.
+See also [`normalise`](@ref) for standardization to mean 0 and standard deviation 1.
+"""
+function rescale(x::AbstractArray; dims=ndims(x), ϵ=ofeltype(x, 1e-5))
+    lo = minimum(x, dims=dims)
+    hi = maximum(x, dims=dims)
+    return (x .- lo) ./ (hi .- lo .+ ϵ)
 end
 
 ofeltype(x, y) = convert(float(eltype(x)), y)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -41,6 +41,22 @@ end
 @testset "normalise" begin
     x = randn(Float32, 3, 2, 2)
     @test normalise(x) == normalise(x; dims=3)
+
+    x = randn(Float32, 3, 4)
+    y = normalise(x; dims=1, ϵ=0)
+    @test mean(y; dims=1) ≈ zeros(Float32, 1, 4) atol=1e-5
+    @test std(y; dims=1, corrected=false) ≈ ones(Float32, 1, 4) atol=1e-5
+end
+
+@testset "rescale" begin
+    x = randn(Float32, 3, 2, 2)
+    @test rescale(x) == rescale(x; dims=3)
+
+    x = randn(Float32, 3, 4)
+    y = rescale(x; dims=1, ϵ=0)
+    @test minimum(y; dims=1) ≈ zeros(Float32, 1, 4) atol=1e-5
+    @test maximum(y; dims=1) ≈ ones(Float32, 1, 4) atol=1e-5
+    @test all(0 .<= y .<= 1)
 end
 
 @testset "chunk" begin


### PR DESCRIPTION
Addresses #123.

Per the discussion in #123, rather than renaming `normalise` (which would break callers and collide awkwardly with `LinearAlgebra.normalize` and `Flux.normalise`), this PR:

- **Keeps `normalise` as-is**, but enriches its docstring so it shows up when searching for *standardization* / *z-score normalization*, and cross-references `rescale`.
- **Adds `rescale`** for min-max scaling to the `[0, 1]` range — the actual "normalization" the issue asks for — mirroring `normalise`'s signature (`dims=ndims(x)`, `ϵ` for numerical stability).

```julia
rescale(x; dims=ndims(x), ϵ=1e-5)  # (x .- min) ./ (max .- min .+ ϵ)
```

### Changes
- `src/utils.jl`: new `rescale`; updated `normalise` docstring.
- `src/MLUtils.jl`: export `rescale`.
- `docs/src/api.md`, `docs/src/index.md`: document/list `rescale`.
- `test/utils.jl`: tests for both functions (mean/std ≈ 0/1 for `normalise`; min/max ≈ 0/1 and range bounds for `rescale`).

Test suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)