### PR TITLE
Support vector indexing of slidingwindow (#213)

### DIFF
--- a/src/slidingwindow.jl
+++ b/src/slidingwindow.jl
@@ -14,6 +14,10 @@ function Base.getindex(A::SlidingWindow, i::Int)
     return getobs(A.data, windowrange)
 end
 
+# Each window is a single observation, so indexing with a vector of
+# integers returns the corresponding windows as a vector.
+Base.getindex(A::SlidingWindow, is::AbstractVector) = [A[i] for i in is]
+
 function getrange(A::SlidingWindow, i::Int)
     offset = 1 + (i-1) * A.stride
     return offset:offset+A.size-1
@@ -47,18 +51,25 @@ passed to `obsview` to get a view of the data along that dimension.
 Note that the windows are not materialized at construction time. 
 To actually get a copy of the data at some window use indexing or [`getobs`](@ref).
 
-When indexing the data is accessed as `getobs(data, idxs)`, with `idxs` an appropriate range of indexes.
+Each window is itself an observation. Indexing with a single integer
+`i` returns the `i`-th window, while indexing with a vector of integers
+(via `s[is]` or `getobs(s, is)`) returns the corresponding windows as a vector.
 
 # Examples
 ```jldoctest
 julia> s = slidingwindow(11:30, size=6)
 slidingwindow(20-element UnitRange{Int64}, size=6, stride=1)
 
-julia> s[1]  # == getobs(data, 1:6)
+julia> s[1]  # == getobs(11:30, 1:6)
 11:16
 
-julia> s[2]  # == getobs(data, 2:7)
+julia> s[2]  # == getobs(11:30, 2:7)
 12:17
+
+julia> getobs(s, [1, 2])  # a vector with the first two windows
+2-element Vector{UnitRange{Int64}}:
+ 11:16
+ 12:17
 ```
 
 The optional parameter `stride` can be used to specify the

--- a/test/slidingwindow.jl
+++ b/test/slidingwindow.jl
@@ -39,4 +39,21 @@
         @test v[3] == x[:, 3:4, :]
         @test v[4] == x[:, 4:5, :]
     end
+
+    @testset "vector indexing (#213)" begin
+        v = slidingwindow(1:20, size=5)
+        # getobs falls back to getindex for AbstractDataContainer
+        @test getobs(v, 1:2) == [v[1], v[2]]
+        @test getobs(v, [1, 3]) == [v[1], v[3]]
+        @test v[1:2] == [v[1], v[2]]
+        @test v[[2, 4]] == [v[2], v[4]]
+        # output is consistent between scalar and vector indexing
+        @test getobs(v, [1])[1] == getobs(v, 1)
+        @test getobs(v, 1:length(v)) == [v[i] for i in 1:length(v)]
+
+        x = [1 2 3 4 5; 6 7 8 9 10]
+        w = slidingwindow(x, size=2)
+        @test getobs(w, 1:2) == [getobs(w, 1), getobs(w, 2)]
+        @test getobs(w, 1:2)[1] == [1 2; 6 7]
+    end
 end


### PR DESCRIPTION
Fixes #213.

## Problem

`getobs(slidingwindow(...), idxs)` failed when `idxs` was a vector or range of integers, even though the docstring stated it should work:

```julia
x = [1 2 3 4 5; 6 7 8 9 10]
data = MLUtils.slidingwindow(x, size=2)
MLUtils.getobs(data, 1)    # works
MLUtils.getobs(data, 1:2)  # ERROR: no method matching getindex(::SlidingWindow, ::UnitRange)
```

`SlidingWindow` is an `AbstractDataContainer`, for which `getobs(data, idx)` falls back to `data[idx]`. Only `getindex(::SlidingWindow, ::Int)` was defined, so any vector/range index hit a `MethodError`.

## Fix

Added `getindex(::SlidingWindow, ::AbstractVector)`. Since each window is a single observation, vector indexing returns the windows as a vector — the standard collection semantics used elsewhere in the package (e.g. `getobs([10,20,30], [1,2]) == [10,20]`):

```julia
julia> getobs(slidingwindow(11:30, size=6), [1, 2])
2-element Vector{UnitRange{Int64}}:
 11:16
 12:17
```

This also fixes batching a `slidingwindow` with `DataLoader`, which relied on the same vector-indexing path.

The docstring was updated (with a new doctest) and two stale comments referencing an undefined `data` were corrected.

## Tests

Added a `"vector indexing (#213)"` testset covering ranges, integer vectors, both `s[is]` and `getobs(s, is)`, scalar/vector consistency, and the issue's matrix example. Full slidingwindow suite passes (39/39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)