### PR TITLE
Fix DataLoader with buffer=true, parallel=true, collate=true (#216)

### DIFF
--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -41,11 +41,18 @@ function _eachobsparallel_buffered(
     buffers = [buffer]
     foreach(_ -> push!(buffers, deepcopy(buffer)), 1:channelsize)
 
+    # `getobs!(buffer, data, i)` may return a value of a different type than
+    # `buffer` itself: with `collate=true` it mutates the per-observation
+    # buffers but returns a freshly batched array. Determine that result type
+    # up front so the `RingBuffer`'s results channel stays concretely typed
+    # (see JuliaML/MLUtils.jl#216).
+    R = _buffered_result_type(data, buffer)
+
     # This ensures the `Loader` will take from the `RingBuffer`s result
     # channel, and that a new results channel is created on repeated
     # iteration. (Since `Loader`) closes the previous at the end of
     # each iteration.
-    setup_channel(sz) = RingBuffer(buffers)
+    setup_channel(sz) = RingBuffer(buffers, R)
 
     return Loader(1:numobs(data); channelsize, setup_channel) do ringbuffer, i
         # Internally, `RingBuffer` will `put!` the result in the results channel
@@ -54,6 +61,11 @@ function _eachobsparallel_buffered(
         end
     end
 end
+
+# Type of a collated batch (which `getobs!` returns) is recorded in `BatchView`'s
+# first type parameter; for any other container the result keeps the buffer's type.
+_buffered_result_type(data::BatchView, buffer) = eltype(data)
+_buffered_result_type(data, buffer) = typeof(buffer)
 
 function _eachobsparallel_unbuffered(data;
         channelsize::Int
@@ -178,28 +190,42 @@ end
 #     Only one result is valid at a time! On the next `take!`, the previous
 #     result will be reused as a buffer and be mutated by a `put!`
 # """
-mutable struct RingBuffer{T}
-    buffers::Channel{T}
-    results::Channel{T}
-    current::T
+# The results channel carries `(buffer, result)` pairs rather than bare results.
+# This way the buffer that produced a result is recycled back into the pool, while
+# the result handed to the consumer may have a different type `R` than the buffer
+# type `B`. That happens with `collate=true`, where `f!` mutates per-observation
+# buffers but returns a freshly batched array (see JuliaML/MLUtils.jl#216). Both
+# types are tracked so the channels stay concretely typed.
+mutable struct RingBuffer{B,R}
+    buffers::Channel{B}
+    results::Channel{Tuple{B,R}}
+    current::B
 end
 
-function RingBuffer(bufs::Vector{T}) where T
+# Single-argument form: the result of `f!` has the same type as the buffer
+# (e.g. in-place `getobs!` without collation).
+RingBuffer(bufs::Vector{B}) where {B} = RingBuffer(bufs, B)
+
+function RingBuffer(bufs::Vector{B}, ::Type{R}) where {B,R}
     size = length(bufs) - 1
-    ch_buffers = Channel{T}(size + 1)
-    ch_results = Channel{T}(size)
+    ch_buffers = Channel{B}(size + 1)
+    ch_results = Channel{Tuple{B,R}}(size)
     foreach(bufs[begin+1:end]) do buf
         put!(ch_buffers, buf)
     end
 
-    return RingBuffer{T}(ch_buffers, ch_results, bufs[begin])
+    return RingBuffer{B,R}(ch_buffers, ch_results, bufs[begin])
 end
 
 
 function Base.take!(ringbuffer::RingBuffer)
+    # Recycle the buffer that produced the previously returned result. This is
+    # deferred until now so a result aliasing its buffer (e.g. `collate=false`)
+    # stays valid until the consumer asks for the next one.
     put!(ringbuffer.buffers, ringbuffer.current)
-    ringbuffer.current = take!(ringbuffer.results)
-    return ringbuffer.current
+    buf, result = take!(ringbuffer.results)
+    ringbuffer.current = buf
+    return result
 end
 
 
@@ -224,7 +250,7 @@ end
 function Base.put!(f!, ringbuffer::RingBuffer)
     buf = take!(ringbuffer.buffers)
     buf_ = f!(buf)
-    put!(ringbuffer.results, buf_)
+    put!(ringbuffer.results, (buf, buf_))
     return buf_
 end
 

--- a/test/dataloader.jl
+++ b/test/dataloader.jl
@@ -315,6 +315,26 @@
         @test first(loader)[1] == trajectory[:, :, :, 1:2, 1:2]
         @test first(loader)[2] == trajectory[:, :, :, 2:3, 1:2]
     end
+
+    @testset "buffer + collate + parallel issue 216" begin
+        # `buffer=true` together with `collate=true` and `parallel=true` used to
+        # error because the collated batch has a different type than the per-obs
+        # buffer it was built from.
+        X_ = rand(Float32, 4, 15)
+        serial = collect(DataLoader(X_; batchsize=2, buffer=true, collate=true, parallel=false))
+        par    = DataLoader(X_; batchsize=2, buffer=true, collate=true, parallel=true)
+        @test_nowarn for _ in par end
+        batches = collect(par)
+        @test all(b -> b isa Matrix{Float32} && size(b, 1) == 4, batches)
+        # parallel order is not guaranteed, so compare as a set of columns
+        cols(bs) = sort(collect(eachcol(reduce(hcat, bs))), by=first)
+        @test cols(batches) == cols(serial)
+
+        # custom collate function over a non-array container
+        loader = DataLoader(["a", "b", "c", "d"]; batchsize=2, buffer=true,
+                            collate=join, parallel=true)
+        @test sort(collect(loader)) == ["ab", "cd"]
+    end
 end
 
 @testset "eachobs" begin


### PR DESCRIPTION
Fixes #216.

## Problem

A `DataLoader` configured with `buffer=true`, `parallel=true`, and `collate=true` errored. The original report saw `UndefVarError: \`A\` not defined in \`MLUtils\``; that came from the FLoops-based loader and disappeared with #215, but the same configuration still failed afterwards with a type error:

```julia
julia> DataLoader(rand(Float32, 4, 20); batchsize=5, buffer=true, collate=true, parallel=true) |> first
ERROR: MethodError: no method matching Vector{Vector{Float32}}(::Matrix{Float32})
```

The parallel buffered path routes results through a `RingBuffer` whose results channel was typed by the **buffer** type. With `collate=true`, `getobs!` mutates the per-observation buffers (a `Vector` of per-obs arrays) but returns a freshly `batch`ed array of a **different** type. Putting that collated result into a channel typed for the buffer failed. The serial path was unaffected because it does not go through the `RingBuffer`.

## Fix

Parametrize `RingBuffer{B,R}` so the buffer type `B` and result type `R` are tracked separately:

- The results channel now carries `(buffer, result)` pairs and recycles the **buffer** (not the result) back into the pool. Recycling stays deferred to the next `take!`, so results that alias their buffer (`collate=false`/`nothing`) remain valid until the consumer asks for the next one — unchanged behavior for those paths.
- `R` is read from `eltype(BatchView)` (its first type parameter, already computed by `BatchView`), so there is **no eager `getobs`/IO** and the channels stay concretely typed. `take!` is type-stable (`@inferred`) for concrete data; for tuple-of-array observations `R` matches `eltype(BatchView)` exactly, i.e. the same type the serial path already yields.
- A single-argument `RingBuffer(bufs)` constructor (defaulting `R = B`) preserves the existing in-place behavior and the standalone `RingBuffer` tests.

## Tests

Added a regression test ("buffer + collate + parallel issue 216") covering plain-array (with serial-vs-parallel correctness), and a custom collate function over a non-array container. Full test suite passes locally.