### PR TITLE
Allow `parallel=n` to set the number of loading workers

### DIFF
--- a/src/dataloader.jl
+++ b/src/dataloader.jl
@@ -71,11 +71,16 @@ The original data is preserved in the `data` field of the DataLoader.
     recursively collating arrays in the last dimensions. See [`MLUtils.batch`](@ref) for more information
     and examples.
   - If a custom function, it will be used in place of `MLUtils.batch`. It should take a vector of observations as input.
-- **`parallel`**: Whether to use load data in parallel using worker threads. Greatly
-    speeds up data loading by factor of available threads. Requires starting
-    Julia with multiple threads. Check `Threads.nthreads()` to see the number of
-    available threads. **Passing `parallel = true` breaks ordering guarantees**.
-    Default `false`.
+- **`parallel`**: Controls parallel data loading with worker tasks spread over the
+    available threads, which greatly speeds up loading when `getobs` is expensive.
+    Requires starting Julia with multiple threads (check `Threads.nthreads()`).
+    **Breaks ordering guarantees.** Accepts:
+    - `false` (default) or `0`: load serially in the iterating task.
+    - `true`: use `Threads.nthreads()` worker tasks.
+    - `n::Integer`: use exactly `n` worker tasks. Since each in-flight worker holds
+      one (possibly batched) observation, a small `n` caps the number of batches
+      built concurrently and hence peak memory; `n = 1` runs a single background
+      worker that overlaps loading with the iterating task.
 - **`partial`**: This argument is used only when `batchsize > 0`.
   If `partial=false` and the number of observations is not divisible by the batchsize,
   then the last mini-batch is dropped. Default `true`.
@@ -143,15 +148,22 @@ struct DataLoader{T<:Union{ObsView,BatchView},B,P,C,O,R<:AbstractRNG}
     buffer::B    # boolean, or external buffer
     partial::Bool
     shuffle::Bool
-    parallel::Bool
+    parallel::Union{Bool,Int}
     collate::C
     rng::R
 end
 
+# Resolve the `parallel` kwarg to a number of loading worker tasks.
+# `false`/`0` (or negative) → serial (0 workers); `true` → all available
+# threads; `n::Integer` → exactly `n`. Defined via dispatch (rather than `==`)
+# so that `Bool <: Integer` does not conflate `true` with `1`.
+_nworkers(parallel::Bool) = parallel ? Threads.nthreads() : 0
+_nworkers(parallel::Integer) = max(Int(parallel), 0)
+
 function DataLoader(
         data;
         buffer = false,
-        parallel::Bool = false,
+        parallel::Union{Bool,Integer} = false,
         shuffle::Bool = false,
         batchsize::Int = 1,
         partial::Bool = true,
@@ -169,10 +181,13 @@ function DataLoader(
         _data = BatchView(_data; batchsize, partial, collate)
     end
 
-    if buffer == true  
+    if buffer == true
         buffer = _create_buffer(_data)
     end
-    P = parallel ? :parallel : :serial
+    # Normalize the stored value (keep `Bool` as-is for faithful printing /
+    # round-tripping, narrow any other `Integer` to `Int` to match the field).
+    parallel = parallel isa Bool ? parallel : Int(parallel)
+    P = _nworkers(parallel) > 0 ? :parallel : :serial
     # for buffer == false and external buffer, we keep as is
 
     T, O, B, C, R = typeof(_data), typeof(data), typeof(buffer), typeof(collate), typeof(rng)
@@ -195,7 +210,7 @@ end
 function Base.iterate(d::DataLoader{T,B,:parallel}) where {T,B}
     @assert d.buffer != false
     data = d.shuffle ? _shuffledata(d.rng, d._data) : d._data
-    iter = _eachobsparallel_buffered(d.buffer, data; channelsize=Threads.nthreads())
+    iter = _eachobsparallel_buffered(d.buffer, data; nworkers=_nworkers(d.parallel))
     obs, state = iterate(iter)
     return obs, (iter, state)
 end
@@ -213,7 +228,7 @@ end
 function Base.iterate(d::DataLoader{T,Bool,:parallel}) where {T}
     @assert d.buffer == false
     data = d.shuffle ? _shuffledata(d.rng, d._data) : d._data
-    iter = _eachobsparallel_unbuffered(data; channelsize=Threads.nthreads())
+    iter = _eachobsparallel_unbuffered(data; nworkers=_nworkers(d.parallel))
     obs, state = iterate(iter)
     return obs, (iter, state)
 end

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -1,9 +1,10 @@
 # """
-#     eachobsparallel(data; buffer, channelsize, basesize)
+#     eachobsparallel(data; buffer, nworkers, channelsize)
 
 # Construct a data iterator over observations in container `data`.
-# It uses available threads as workers to load observations in
-# parallel, leading to large speedups when threads are available.
+# It uses worker tasks spread over the available threads to load
+# observations in parallel, leading to large speedups when threads
+# are available.
 
 # To ensure that the active Julia session has multiple threads
 # available, check that `Threads.nthreads() > 1`. You can start
@@ -19,25 +20,30 @@
 #     `data`. Setting `buffer = true` means that when using the iterator, an
 #     observation is only valid for the current loop iteration.
 #     You can also pass in a preallocated `buffer = getobs(data, 1)`.
-# - `channelsize = Threads.nthreads()`: the number of observations that are prefetched.
+# - `nworkers = Threads.nthreads()`: the number of worker tasks that load observations
+#     concurrently. Each in-flight worker holds one (possibly batched) observation, so
+#     lowering `nworkers` is the main lever for capping peak memory.
+# - `channelsize = nworkers`: the number of observations that are prefetched.
 #     Increasing `channelsize` can lead to speedups when per-observation processing
 #     time is irregular but will cause higher memory usage.
 # """
 function eachobsparallel(
         data;
         buffer::Bool = false,
-        channelsize::Int = Threads.nthreads())
+        nworkers::Int = Threads.nthreads(),
+        channelsize::Int = nworkers)
     if buffer
-        return _eachobsparallel_buffered(buffer, data; channelsize)
+        return _eachobsparallel_buffered(buffer, data; nworkers, channelsize)
     else
-        return _eachobsparallel_unbuffered(data; channelsize)
+        return _eachobsparallel_unbuffered(data; nworkers, channelsize)
     end
 end
 
 function _eachobsparallel_buffered(
         buffer,
         data;
-        channelsize::Int)
+        nworkers::Int,
+        channelsize::Int = nworkers)
     buffers = [buffer]
     foreach(_ -> push!(buffers, deepcopy(buffer)), 1:channelsize)
 
@@ -54,7 +60,7 @@ function _eachobsparallel_buffered(
     # each iteration.
     setup_channel(sz) = RingBuffer(buffers, R)
 
-    return Loader(1:numobs(data); channelsize, setup_channel) do ringbuffer, i
+    return Loader(1:numobs(data); nworkers, channelsize, setup_channel) do ringbuffer, i
         # Internally, `RingBuffer` will `put!` the result in the results channel
         put!(ringbuffer) do buf
             getobs!(buf, data, i)
@@ -68,9 +74,10 @@ _buffered_result_type(data::BatchView, buffer) = eltype(data)
 _buffered_result_type(data, buffer) = typeof(buffer)
 
 function _eachobsparallel_unbuffered(data;
-        channelsize::Int
+        nworkers::Int,
+        channelsize::Int = nworkers
     )
-    return Loader(1:numobs(data); channelsize) do ch, i
+    return Loader(1:numobs(data); nworkers, channelsize) do ch, i
         obs = getobs(data, i)
         put!(ch, obs)
     end
@@ -84,16 +91,17 @@ end
 
 
 # """
-#     Loader(f, args; channelsize, setup_channel)
+#     Loader(f, args; nworkers, channelsize, setup_channel)
 
 # Create a threaded iterator that iterates over `(f(arg) for arg in args)`
-# using threads that prefill a channel of length `channelsize`.
+# using `nworkers` worker tasks that prefill a channel of length `channelsize`.
 
 # Note: results may not be returned in the correct order.
 # """
 struct Loader
     f
     argiter::AbstractVector
+    nworkers::Int
     channelsize::Int
     setup_channel
 end
@@ -101,9 +109,10 @@ end
 function Loader(
         f,
         argiter;
-        channelsize::Int = Threads.nthreads(),
+        nworkers::Int = Threads.nthreads(),
+        channelsize::Int = nworkers,
         setup_channel = sz -> Channel(sz))
-    Loader(f, argiter, channelsize, setup_channel)
+    Loader(f, argiter, nworkers, channelsize, setup_channel)
 end
 
 Base.length(loader::Loader) = length(loader.argiter)
@@ -116,7 +125,7 @@ end
 
 function Base.iterate(loader::Loader)
     ch = loader.setup_channel(loader.channelsize)
-    basesize = length(loader.argiter) ÷ Threads.nthreads()
+    basesize = length(loader.argiter) ÷ max(loader.nworkers, 1)
     task = Threads.@spawn begin
         try
             _spawn_foreach(loader.f, ch, loader.argiter,

--- a/test/dataloader.jl
+++ b/test/dataloader.jl
@@ -380,6 +380,40 @@ end
             @test_nowarn for _ in iter end
         end
     end
+
+    @testset "parallel worker count" begin
+        # `parallel` accepts a worker count, with `true` = nthreads and `0`/`false` = serial
+        @test MLUtils._nworkers(false) == 0
+        @test MLUtils._nworkers(0) == 0
+        @test MLUtils._nworkers(-3) == 0
+        @test MLUtils._nworkers(true) == Threads.nthreads()
+        @test MLUtils._nworkers(3) == 3
+        # `Bool <: Integer`, so `true` must not be conflated with `1`
+        @test MLUtils._nworkers(1) == 1
+
+        # codepath dispatch: 0/false serial, positive ints / true parallel
+        mode(d) = typeof(d).parameters[3]
+        @test mode(DataLoader(1:50; parallel=false)) === :serial
+        @test mode(DataLoader(1:50; parallel=0)) === :serial
+        @test mode(DataLoader(1:50; parallel=true)) === :parallel
+        @test mode(DataLoader(1:50; parallel=1)) === :parallel
+        @test mode(DataLoader(1:50; parallel=4)) === :parallel
+
+        # the raw value round-trips (faithful printing / reconstruction)
+        @test DataLoader(1:50; parallel=3).parallel === 3
+        @test DataLoader(1:50; parallel=true).parallel === true
+        @test DataLoader(1:50; parallel=false).parallel === false
+
+        # every observation is loaded exactly once regardless of worker count
+        ref = collect(1:50)
+        for p in (false, 0, 1, 2, true)
+            @test sort(collect(eachobs(1:50; parallel=p))) == ref
+            @test sort(collect(eachobs(1:50; parallel=p, buffer=true))) == ref
+            batches = collect(eachobs(1:50; parallel=p, batchsize=5))
+            @test length(batches) == 10
+            @test sort(reduce(vcat, batches)) == ref
+        end
+    end
 end
 
 @testset "Empty handling" begin


### PR DESCRIPTION
Allow to set the number of parallel workers in the DataLoader (previously other serial behavior or num workers = num threads).

Fixes #210 (DataLoader parallel loading uses too much memory).

## What

Extends the `parallel` kwarg on `DataLoader`/`eachobs` from `Bool` to `Union{Bool,Integer}`:

| `parallel=` | meaning |
|---|---|
| `false` / `0` | serial (current default) |
| `true` | `Threads.nthreads()` workers (current behavior) |
| `n::Integer` | exactly `n` worker tasks |
| `1` | one background worker overlapping load with the iterating task |

This follows PyTorch's convention (`num_workers=0` ⇒ main-process/serial), folded onto the existing kwarg rather than adding a separate `num_workers` — so there's no contradictory state like `parallel=false, num_workers=8`.

## Why

In the parallel path each in-flight worker holds one *whole (collated) batch*, so peak memory is dominated by `nworkers × batchsize`, **not** the prefetch channel depth. The worker count was hardcoded to `Threads.nthreads()`, so a 16-thread session building ~600 MB batches kept ~16–32 batches live → the 40 GB RSS in #210. An experiment confirmed `channelsize` is *not* a useful memory lever (lowering it didn't help, sometimes hurt), while the worker count is — so this exposes the worker count and leaves `channelsize` derived from it.

## How

- `_nworkers` resolves the kwarg, defined by **dispatch** (not `==`) so `Bool <: Integer` doesn't conflate `true` with `1`.
- Threaded through `eachobsparallel` → `Loader` → `basesize = length ÷ nworkers`.
- `channelsize` now defaults to `nworkers` (was `nthreads()`), so the prefetch buffer scales with the worker count instead of the global thread count.
- The raw `parallel` value is stored unchanged for faithful printing / reconstruction (`parallel=true` doesn't silently round-trip to `parallel=8`).
- `parallel=true` resolves to `nthreads()`, so **all existing defaults and behavior are unchanged**. Widening `Bool` → `Union{Bool,Integer}` is backward compatible.

## Benchmark

Reproducing the #210 setup on a 16-core / 32-thread Threadripper (122 GiB RAM): 40 batches × 1024 images (224×224×3 `Float32`, ~600 MB/collated-batch), `collate=true`, `rand`-based `getobs` (CPU-bound, no I/O). Each cell is a fresh process so `Sys.maxrss` is clean. (`getobs!` defined so `buffer=true` reuses per-observation image buffers.)

**Peak RSS (GB):**

| `parallel` | `buffer` | t=4 | t=8 | t=16 |
|---|---|---|---|---|
| `false` | `false` | 2.6 | 2.6 | 2.4 |
| `false` | `true` | **1.5** | **1.5** | **1.5** |
| `1` | `false` | 2.5 | 2.4 | 2.4 |
| `1` | `true` | 2.1 | 3.3 | 3.3 |
| `2` | `false` | 4.0 | 4.0 | 4.1 |
| `2` | `true` | 4.4 | 5.0 | 4.4 |
| `4` | `false` | 6.6 | 6.6 | 6.6 |
| `4` | `true` | 9.0 | 8.5 | 7.9 |
| `auto` | `false` | 6.6 | 9.1 | **15.3** |
| `auto` | `true` | 8.5 | 11.4 | **23.5** |

**Time in seconds (GC% in parens):**

| `parallel` | `buffer` | t=4 | t=8 | t=16 |
|---|---|---|---|---|
| `false` | `false` | 6.98 (25%) | 6.51 (21%) | 7.04 (22%) |
| `false` | `true` | 5.35 (8%) | 5.26 (8%) | 5.75 (10%) |
| `1` | `false` | 7.30 (24%) | 7.95 (23%) | 7.28 (23%) |
| `1` | `true` | 5.41 (8%) | 5.41 (7%) | 5.46 (8%) |
| `2` | `false` | 6.29 (26%) | 6.00 (22%) | 6.06 (24%) |
| `2` | `true` | 5.46 (15%) | 5.33 (13%) | 5.41 (13%) |
| `4` | `false` | 5.55 (29%) | 5.51 (21%) | 5.78 (22%) |
| `4` | `true` | 5.62 (16%) | 5.40 (13%) | 5.59 (13%) |
| `auto` | `false` | 5.58 (29%) | **4.82 (23%)** | 5.67 (21%) |
| `auto` | `true` | 5.60 (16%) | 6.26 (14%) | 5.35 (16%) |

**Takeaways:**

1. **`parallel=n` is the memory dial.** With `buffer=false`, peak RSS tracks `nworkers × batchsize`: 2.5 (serial) → 2.4 (`1`) → 4 (`2`) → 6.6 (`4`) → **15.3 GB** (`auto` @ 16 threads). `parallel=1`/`2` stay bounded regardless of thread count. `auto` is what blows up — and worsens with thread count.
2. **`buffer=true` is double-edged and must be paired with *low* `nworkers`.** Serial / `parallel=1`: it's the lowest memory (1.5 GB, preallocation reuse, ~ the SimpleLoader in #210). But `auto, buffer=true` is the *highest* (23.5 GB), because the buffer pool is `(nworkers+1)` whole batches of per-observation buffers held for the whole iteration, on top of the in-flight collated outputs.
3. **Timings are a narrow, noisy band (4.8–8.0 s, ~15% run-to-run).** `getobs` is pure CPU with no I/O to overlap and only 40 batches, so `parallel` barely moves wall-clock here — treat RSS as the robust number. The consistent time win is `buffer=true` (halves GC from ~21–29% to ~7–16%). On real I/O-bound loading, higher `parallel` would help throughput, making the memory/throughput trade-off the actual decision.
4. **Sweet spot for large batches: `parallel=2, buffer=true`** — ~5.4 s, ~13% GC, ~4–5 GB, versus `auto`'s 15–23 GB.

## Tests

New `parallel worker count` testset: `_nworkers` mapping incl. the `true`/`1` distinction, `:serial`/`:parallel` codepath dispatch, raw-value round-trip, and that every observation is loaded exactly once for `parallel ∈ (false, 0, 1, 2, true)` across unbuffered / buffered / batched paths. Also verified `parallel=n` composes with the `buffer=true` + `collate=true` path from #216/#228 (stays `@inferred`-stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)