### PR TITLE
Allow passing an rng to randobs

### DIFF
--- a/src/randobs.jl
+++ b/src/randobs.jl
@@ -1,12 +1,16 @@
-# TODO: allow passing a rng as first parameter
-
 """
-    randobs(data, [n])
+    randobs([rng], data, [n])
+
 Pick a random observation or a batch of `n` random observations
 from `data`.
 For this function to work, the type of `data` must implement
 [`numobs`](@ref) and [`getobs`](@ref).
-"""
-randobs(data) = getobs(data, rand(1:numobs(data)))
 
-randobs(data, n) = getobs(data, rand(1:numobs(data), n))
+A random number generator `rng` can be optionally passed as the
+first argument.
+"""
+randobs(data) = randobs(Random.default_rng(), data)
+randobs(rng::AbstractRNG, data) = getobs(data, rand(rng, 1:numobs(data)))
+
+randobs(data, n) = randobs(Random.default_rng(), data, n)
+randobs(rng::AbstractRNG, data, n) = getobs(data, rand(rng, 1:numobs(data), n))

--- a/test/randobs.jl
+++ b/test/randobs.jl
@@ -2,7 +2,18 @@ x = randobs(X[:,1:4])
 @test size(x) == (4,)
 @test any(X[:,i] == x for i in 1:4) 
 
-x = randobs(X[:,1:4], 2) 
+x = randobs(X[:,1:4], 2)
 @test size(x) == (4, 2)
-@test any(X[:,i] == x[:,1] for i in 1:4) 
+@test any(X[:,i] == x[:,1] for i in 1:4)
 @test any(X[:,i] == x[:,2] for i in 1:4)
+
+@testset "rng" begin
+    x = randobs(MersenneTwister(0), X)
+    @test size(x) == (4,)
+    @test any(X[:,i] == x for i in 1:15)
+    @test randobs(MersenneTwister(0), X) == randobs(MersenneTwister(0), X)
+
+    x = randobs(MersenneTwister(0), X, 3)
+    @test size(x) == (4, 3)
+    @test randobs(MersenneTwister(0), X, 3) == randobs(MersenneTwister(0), X, 3)
+end


### PR DESCRIPTION
Closes the `randobs` item in #227 (the `# TODO: allow passing a rng as first parameter` marker).

`randobs` now accepts an optional `rng::AbstractRNG` as the first argument, following the convention already used by `splitobs`, `oversample`, and `undersample` (`[rng,] data`, defaulting to `Random.default_rng()`):

```julia
randobs(data)         # uses Random.default_rng()
randobs(rng, data)
randobs(data, n)      # uses Random.default_rng()
randobs(rng, data, n)
```

The docstring signature is updated to `randobs([rng], data, [n])` and the orphaned TODO comment is removed.

Tests added in `test/randobs.jl` cover the new signatures and check that seeding the same `MersenneTwister` yields identical results. The `randobs` testset passes (10/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)