### PR TITLE
Add batched searchsorted with GPU support (#218)

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -73,6 +73,8 @@ undersample
 ## Operations
 
 ```@docs
+batched_searchsortedfirst
+batched_searchsortedlast
 chunk
 flatten
 group_counts

--- a/src/MLUtils.jl
+++ b/src/MLUtils.jl
@@ -72,7 +72,9 @@ export batch,
        unbatch
 
 include("utils.jl")
-export chunk,
+export batched_searchsortedfirst,
+       batched_searchsortedlast,
+       chunk,
        falses_like,
        fill_like,
        flatten,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -677,3 +677,98 @@ function rrule(::typeof(fill_like), x::AbstractArray, val, T::Type, sz)
     return fill_like(x, val, T, sz), fill_like_pullback
 end
 
+"""
+    batched_searchsortedfirst(xp, x; dims=1, rev=false)
+
+Batched, GPU-friendly version of `Base.searchsortedfirst`.
+
+For each query in `x`, return the index of the first element of the sorted
+collection `xp` that is greater than or equal to it (the leftmost position at
+which the query could be inserted while keeping `xp` sorted). Pass `rev=true`
+when `xp` is sorted in descending order.
+
+The search runs along dimension `dims` of `xp`. `x` and `xp` must have the same
+size along all other dimensions (or `xp` may be a vector, in which case it is
+searched for every query in `x`). The result has the same size as `x`, so that
+for `dims=1`, `xp[result[i, j], j] >= x[i, j]`.
+
+See also [`batched_searchsortedlast`](@ref).
+
+# Examples
+
+```jldoctest
+julia> v = [1, 3, 5, 7, 9];
+
+julia> batched_searchsortedfirst(v, [4, 5, 8])
+3-element Vector{Int64}:
+ 3
+ 3
+ 5
+
+julia> xp = [1 2; 3 4; 5 6];   # two sorted columns: [1,3,5] and [2,4,6]
+
+julia> batched_searchsortedfirst(xp, [2 5; 4 1])
+2×2 Matrix{Int64}:
+ 2  3
+ 3  1
+```
+"""
+function batched_searchsortedfirst(xp::AbstractArray, x::AbstractArray; dims::Integer=1, rev::Bool=false)
+    cmp = _searchsorted_count(xp, x, dims, rev ? (>) : (<))
+    return cmp .+ 1
+end
+
+"""
+    batched_searchsortedlast(xp, x; dims=1, rev=false)
+
+Batched, GPU-friendly version of `Base.searchsortedlast`.
+
+For each query in `x`, return the index of the last element of the sorted
+collection `xp` that is less than or equal to it (the rightmost position at
+which the query could be inserted while keeping `xp` sorted). Pass `rev=true`
+when `xp` is sorted in descending order.
+
+The search runs along dimension `dims` of `xp`. `x` and `xp` must have the same
+size along all other dimensions (or `xp` may be a vector, in which case it is
+searched for every query in `x`). The result has the same size as `x`, so that
+for `dims=1`, `xp[result[i, j], j] <= x[i, j]`.
+
+See also [`batched_searchsortedfirst`](@ref).
+
+# Examples
+
+```jldoctest
+julia> v = [1, 3, 5, 7, 9];
+
+julia> batched_searchsortedlast(v, [4, 5, 8])
+3-element Vector{Int64}:
+ 2
+ 3
+ 4
+
+julia> xp = [1 2; 3 4; 5 6];   # two sorted columns: [1,3,5] and [2,4,6]
+
+julia> batched_searchsortedlast(xp, [2 5; 4 1])
+2×2 Matrix{Int64}:
+ 1  2
+ 2  0
+```
+"""
+function batched_searchsortedlast(xp::AbstractArray, x::AbstractArray; dims::Integer=1, rev::Bool=false)
+    return _searchsorted_count(xp, x, dims, rev ? (>=) : (<=))
+end
+
+# Count, for each query in `x`, how many elements of `xp` satisfy `cmp(xp, x)`
+# along dimension `dims`. The comparison is broadcast over an extra axis, so the
+# whole computation is vectorized and stays on the GPU. `xp` may be a vector, in
+# which case it is broadcast against every batch of `x`.
+function _searchsorted_count(xp::AbstractArray, x::AbstractArray, dims::Integer, cmp)
+    xpe = unsqueeze(xp; dims = dims + 1)   # search dim stays at `dims`
+    xe = unsqueeze(x; dims = dims)         # query dim moves to `dims + 1`
+    counts = sum(cmp.(xpe, xe); dims)
+    return dropdims(counts; dims)
+end
+
+@non_differentiable batched_searchsortedfirst(::Any...)
+@non_differentiable batched_searchsortedlast(::Any...)
+

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -215,3 +215,57 @@ end
     @test rpad_constant([1 2; 3 4], 4) == [1 2 0 0; 3 4 0 0; 0 0 0 0; 0 0 0 0]
     @test rpad_constant([1 2; 3 4], (3, 4)) == [1 2 0 0; 3 4 0 0; 0 0 0 0]
 end
+
+@testset "batched_searchsorted" begin
+    # vector haystack matches Base.searchsorted{first,last} elementwise
+    v = sort(randn(20))
+    q = randn(8)
+    @test batched_searchsortedfirst(v, q) == searchsortedfirst.(Ref(v), q)
+    @test batched_searchsortedlast(v, q) == searchsortedlast.(Ref(v), q)
+
+    # descending haystack
+    vr = sort(randn(20); rev=true)
+    @test batched_searchsortedfirst(vr, q; rev=true) == searchsortedfirst.(Ref(vr), q; rev=true)
+    @test batched_searchsortedlast(vr, q; rev=true) == searchsortedlast.(Ref(vr), q; rev=true)
+
+    # documented examples
+    @test batched_searchsortedfirst([1, 3, 5, 7, 9], [4, 5, 8]) == [3, 3, 5]
+    @test batched_searchsortedlast([1, 3, 5, 7, 9], [4, 5, 8]) == [2, 3, 4]
+
+    # batched along dim 1 (last dim is the batch): each column searched independently
+    xp = sort(randn(10, 5); dims=1)
+    x = randn(4, 5)
+    rf = batched_searchsortedfirst(xp, x)
+    rl = batched_searchsortedlast(xp, x)
+    @test size(rf) == size(x) == size(rl)
+    for j in 1:5
+        @test rf[:, j] == searchsortedfirst.(Ref(xp[:, j]), x[:, j])
+        @test rl[:, j] == searchsortedlast.(Ref(xp[:, j]), x[:, j])
+    end
+
+    # batched along a non-default dim
+    xp2 = sort(randn(5, 10); dims=2)
+    x2 = randn(5, 4)
+    r2 = batched_searchsortedlast(xp2, x2; dims=2)
+    @test size(r2) == size(x2)
+    for i in 1:5
+        @test r2[i, :] == searchsortedlast.(Ref(xp2[i, :]), x2[i, :])
+    end
+
+    # a vector haystack broadcasts against a batched query
+    @test batched_searchsortedfirst(v, x) == searchsortedfirst.(Ref(v), x)
+
+    if CUDA.functional()
+        CUDA.allowscalar(false)
+        try
+            xpg, xg = cu(xp), cu(x)
+            for f in (batched_searchsortedfirst, batched_searchsortedlast)
+                rg = f(xpg, xg)
+                @test rg isa CuArray
+                @test Array(rg) == f(xp, x)
+            end
+        finally
+            CUDA.allowscalar(true)
+        end
+    end
+end


### PR DESCRIPTION
Closes #218 (originally [FluxML/NNlib.jl#404](https://github.com/FluxML/NNlib.jl/issues/404)).

Adds `batched_searchsortedfirst` and `batched_searchsortedlast`, batched and GPU-friendly analogues of `Base.searchsortedfirst`/`searchsortedlast`. The naming follows NNlib's `batched_mul` convention, since the request came from NNlib.

```julia
julia> batched_searchsortedfirst([1, 3, 5, 7, 9], [4, 5, 8])
3-element Vector{Int64}:
 3
 3
 5

julia> xp = [1 2; 3 4; 5 6];   # two sorted columns: [1,3,5] and [2,4,6]

julia> batched_searchsortedlast(xp, [2 5; 4 1])
2×2 Matrix{Int64}:
 1  2
 2  0
```

### GPU-friendly by construction

The search runs along dimension `dims` (default 1) and reduces to a single broadcast comparison plus a `sum` reduction along `dims` — no scalar indexing, so it stays on the GPU. This replaces the `unbatch`/`map`/`searchsortedlast.` workaround in the issue, which fell back to the CPU.

- `x` must match `xp` in size along all dims except `dims`, where the result takes `x`'s size.
- A vector `xp` broadcasts against a batched `x` (the exact case from the NNlib issue), handled for free by Julia broadcasting.
- `rev=true` supports descending-sorted `xp`.
- Both are marked `@non_differentiable` (they return integer indices).

### Tests

Added a `batched_searchsorted` testset that cross-checks against `Base.searchsorted*` for vectors, batched columns/rows (`dims=1`/`dims=2`), `rev=true`, and vector-broadcast, plus a GPU block guarded by `CUDA.functional()` with scalar indexing disabled. Verified locally on a CUDA GPU: results match the CPU path and outputs stay `CuArray`.

### API note

I went with two `batched_*` functions mirroring `Base`. If a single torch-style `searchsorted(...; side=...)` or different naming is preferred, happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)