### PR TITLE
Add generic show method for AbstractDataContainer (#227)

### DIFF
--- a/src/datacontainer.jl
+++ b/src/datacontainer.jl
@@ -14,4 +14,7 @@ Base.iterate(x::AbstractDataContainer, state = 1) =
 Base.lastindex(x::AbstractDataContainer) = numobs(x)
 Base.firstindex(::AbstractDataContainer) = 1
 
-# TODO: add generic show method. See DataLoader's show for inspiration.
+# Generic fallback for subtypes that don't define their own `show`.
+# Concrete subtypes with a more specific `show` method take precedence.
+Base.show(io::IO, x::AbstractDataContainer) =
+    print(io, numobs(x), "-element ", nameof(typeof(x)))

--- a/test/obstransform.jl
+++ b/test/obstransform.jl
@@ -115,6 +115,14 @@ end
         @test data12[3] == 3
         @test data12[6] == [1.0, 1.0]
     end
+
+    @testset "show" begin
+        # JoinedData has no specific `show` method and relies on the
+        # generic AbstractDataContainer fallback.
+        data = joinobs(1:10, 11:20)
+        @test sprint(show, data) == "20-element JoinedData"
+        @test sprint(show, MIME"text/plain"(), data) == "20-element JoinedData"
+    end
 end
 
 @testset "shuffleobs" begin


### PR DESCRIPTION
Addresses the `AbstractDataContainer` item in the tracking issue #227:

> **No generic `show` for `AbstractDataContainer`** — `src/datacontainer.jl:17`: `# TODO: add generic show method. See DataLoader's show for inspiration.`

## What

Adds a generic 2-argument `show` fallback on `AbstractDataContainer`:

```julia
Base.show(io::IO, x::AbstractDataContainer) =
    print(io, numobs(x), "-element ", nameof(typeof(x)))
```

## Why this form

- All concrete subtypes (`ObsView`, `BatchView`, `ArrayObsView`, `MappedData`, `NamedTupleData`, `SlidingWindow`) already define their own 2-arg `show`. Since those are more specific, dispatch keeps using them — their display is **unchanged**.
- The only subtype without a `show` is `JoinedData`, which previously printed Julia's default struct dump (`MLUtils.JoinedData{Tuple{…},2}((1:10, 11:20), (10, 10))`). It now prints `20-element JoinedData`, consistent with how arrays and `DataLoader` display.
- A 3-arg `MIME"text/plain"` method was deliberately **not** added on the abstract type: it would override the subtypes' own 2-arg `show` in the REPL. The 2-arg fallback composes correctly with Base's default `show(io, ::MIME, x) = show(io, x)`.

## Tests

Added a `show` testset under `joinobs` in `test/obstransform.jl`. Verified locally that `obstransform`, `obsview`, `batchview`, and `slidingwindow` suites pass and `detect_ambiguities` reports no new ambiguities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)