### PR TITLE
Give each DataLoader disjoint worker processes under num_workers

### DIFF
--- a/src/distributed.jl
+++ b/src/distributed.jl
@@ -55,28 +55,50 @@ end
 # ---------------------------------------------------------------------------
 
 # A persistent, lazily-grown set of managed worker processes (like PyTorch's
-# `persistent_workers=True`), reused across loaders and epochs to amortize startup. Stored
-# as an ordered pid vector so that slicing `[1:n]` is deterministic: a `num_workers=n`
-# loader always binds to the *same* first `n` workers, and two loaders requesting the same
-# `n` share them rather than fighting over the whole set. The lock makes concurrent
-# first-iterations grow the set atomically (no double `addprocs`, no orphaned pids).
-const _POOL_PIDS = Ref{Vector{Int}}(Int[])
+# `persistent_workers=True`), reused across epochs to amortize startup. Unlike PyTorch —
+# where every `DataLoader` spawns its *own* workers — MLUtils keeps a single shared pool
+# but hands each *live* loader a **disjoint** block of workers. Two loaders alive at once
+# (a train and a validation loader, or a loader iterated inside another's loop) therefore
+# never bind to the same processes, so they can't contend for them or double-cache their
+# `data` on them. Workers whose owning loader has been garbage-collected return to the warm
+# pool and are reused by the next loader instead of being killed.
+#
+# `_ALL_PIDS` is every managed worker (leased + free). `_LEASES` records, per live loader,
+# a *weak* reference to its `_cache` (a per-loader mutable object that lives exactly as long
+# as the loader) alongside the pids it owns. The weak ref lets a collected loader's workers
+# re-enter the free set: the GC nulls the ref, and the next allocation prunes it. The lock
+# makes concurrent first-iterations allocate atomically (no double `addprocs`, and never two
+# loaders handed the same pid).
 const _POOL_LOCK = ReentrantLock()
+const _ALL_PIDS = Int[]
+const _LEASES = Tuple{WeakRef,Vector{Int}}[]
 
-# Ensure at least `n` managed worker processes exist; return the full ordered pid vector.
-function _ensure_pool(n::Int, data)
+# Lease `n` worker processes for `owner`, disjoint from every other live loader's workers;
+# spawn more only if fewer than `n` are currently free. Returns the leased pids.
+function _lease_workers(n::Int, data, owner)
     pids = lock(_POOL_LOCK) do
-        pids = _POOL_PIDS[]
-        if length(pids) < n
+        # Prune workers that died, and leases whose loader was garbage-collected (weak ref
+        # nulled) or a stale prior lease for this same `owner`; the pids they held re-enter
+        # the free set. The complement of what live loaders still hold is the free set.
+        filter!(in(Distributed.procs()), _ALL_PIDS)
+        filter!(e -> !(e[1].value === nothing || e[1].value === owner), _LEASES)
+        leased = Int[]
+        for (_, owned) in _LEASES
+            append!(leased, owned)
+        end
+        free = setdiff(_ALL_PIDS, leased)
+        if length(free) < n
             # Match the parent's environment so workers instantiate the same project (and,
             # for HF datasets, the same CondaPkg Python). `active_project()` is usually a path.
             proj = Base.active_project()
             exeflags = proj === nothing ? `` : `--project=$proj`
-            newpids = addprocs(n - length(pids); exeflags)
-            pids = vcat(pids, newpids)
-            _POOL_PIDS[] = pids
+            newpids = addprocs(n - length(free); exeflags)
+            append!(_ALL_PIDS, newpids)
+            append!(free, newpids)
         end
-        return pids
+        mine = free[1:n]
+        push!(_LEASES, (WeakRef(owner), mine))
+        return mine
     end
     _load_modules_on_workers(data, pids)
     return pids
@@ -111,8 +133,9 @@ end
 # is only for releasing them earlier (e.g. to reclaim memory in a long-lived session).
 function close_dataloader_pool()
     lock(_POOL_LOCK) do
-        isempty(_POOL_PIDS[]) || rmprocs(_POOL_PIDS[]...)
-        _POOL_PIDS[] = Int[]
+        isempty(_ALL_PIDS) || rmprocs(_ALL_PIDS...)
+        empty!(_ALL_PIDS)
+        empty!(_LEASES)
     end
     return nothing
 end
@@ -157,16 +180,15 @@ function _distributed_loader(d::DataLoader)
         return DistributedLoader(ch, nothing, 0)
     end
 
-    # Cache this loader's own `CachingPool` (over exactly its `num_workers` workers) + the
+    # Cache this loader's own `CachingPool` (over its leased, disjoint workers) + the
     # closure, so that `data` stays cached on the workers across epochs (only the shuffled
     # index sets change). Rebuild if those workers were torn down (e.g. by
     # `close_dataloader_pool`) — checked against the cached pids, not the shared global set.
+    # `d._cache` is the loader-lifetime key under which the lease is held, so the workers
+    # are released back to the pool automatically once this loader is garbage-collected.
     cache = d._cache[]
     if cache === nothing || !_pool_alive(cache.pids)
-        allpids = _ensure_pool(d.num_workers, d.data)
-        # Bind to exactly `num_workers` workers so distinct loaders don't grab the whole,
-        # possibly larger, shared set (deterministic slice: same request → same workers).
-        pids = allpids[1:min(d.num_workers, length(allpids))]
+        pids = _lease_workers(d.num_workers, d.data, d._cache)
         cpool = CachingPool(pids)
         f = _worker_closure(collate, d.data)
         cache = (pids = pids, cpool = cpool, f = f)

--- a/test/distributed.jl
+++ b/test/distributed.jl
@@ -52,15 +52,16 @@ end
     labels = sort(reduce(vcat, [b[2] for b in batches]))
     @test labels == collect(1:20)
 
-    # a second epoch reuses the warm pool + cached data
+    # a second epoch reuses the loader's own warm workers + cached data
     nprocs_before = nprocs()
     @test length(collect(dl)) == 5
     @test nprocs() == nprocs_before   # no new workers spawned
 
-    # a *distinct* loader also reuses the persistent pool (no extra addprocs)
+    # a *distinct* loader, while `dl` is still alive, gets its OWN disjoint workers so
+    # concurrent/nested loaders never contend for the same processes
     dl2 = DataLoader(D; batchsize=5, num_workers=2)
     @test length(collect(dl2)) == 4
-    @test nprocs() == nprocs_before
+    @test isempty(intersect(dl._cache[].pids, dl2._cache[].pids))
 
     # early termination (`first`) yields a valid batch and does not hang
     @test size(first(DataLoader(D; batchsize=5, num_workers=2))) == (4, 5)
@@ -75,8 +76,13 @@ end
 # `Serialization` dispatched over MLUtils' `CachingPool` is reconstructed exactly
 # ONCE per worker (not once per batch), so `data` crosses the process boundary once.
 @testset "reconstruct-once per worker (CachingPool)" begin
-    # Force the managed pool to exist so `@everywhere` can define the toy type on it.
-    collect(DataLoader(rand(2, 6); batchsize=3, num_workers=2))
+    MLUtils.close_dataloader_pool()
+    # Force the managed pool to exist so `@everywhere` can define the toy type on it. The
+    # throwaway loader is created inside a function so it becomes unreachable on return; a
+    # GC below then frees its workers back to the pool and the real loader re-leases those
+    # same (now type-aware) workers rather than spawning fresh, type-less ones.
+    _warmup(n) = (collect(DataLoader(rand(2, 6); batchsize=3, num_workers=n)); nothing)
+    _warmup(2)
     @test length(workers()) >= 2
 
     @everywhere begin
@@ -101,6 +107,10 @@ end
 
     foreach(w -> remotecall_fetch(_reset_recon, w), workers())
 
+    # Release the throwaway loader's lease so the real loader reuses those workers
+    # (which now have `ReconCounter` defined) instead of spawning fresh, type-less ones.
+    GC.gc(); GC.gc()
+
     data = ReconCounter(100)
     dl = DataLoader(data; batchsize=10, num_workers=2, collate=false)  # 10 batches
     batches = collect(dl)
@@ -114,27 +124,47 @@ end
     @test sum(counts) >= 1
 end
 
-@testset "multiple loaders share one pool, each bound to its own num_workers" begin
+@testset "concurrent loaders get disjoint workers (no contention)" begin
     MLUtils.close_dataloader_pool()
     D = reshape(collect(1.0:60.0), 4, 15)
 
-    dlbig = DataLoader(D; batchsize=5, num_workers=3)
-    @test length(collect(dlbig)) == 3
-    @test nprocs() == 4                      # main + 3
-    @test length(dlbig._cache[].pids) == 3
+    dlA = DataLoader(D; batchsize=5, num_workers=2)
+    @test length(collect(dlA)) == 3
+    @test nprocs() == 3                      # main + 2
+    pidsA = copy(dlA._cache[].pids)
+    @test length(pidsA) == 2
 
-    # a smaller loader created afterwards must NOT grab the whole (larger) pool
-    dlsmall = DataLoader(D; batchsize=5, num_workers=2)
-    @test length(collect(dlsmall)) == 3
-    @test nprocs() == 4                      # reused, no new workers
-    @test length(dlsmall._cache[].pids) == 2 # bound to exactly 2, not 3
-    @test dlsmall._cache[].pids == dlbig._cache[].pids[1:2]  # deterministic slice
+    # a second loader created while `dlA` is still alive must get its OWN, disjoint
+    # workers — the fix for the bug where distinct loaders shared (and fought over) pids
+    dlB = DataLoader(D; batchsize=5, num_workers=2)
+    @test length(collect(dlB)) == 3
+    pidsB = copy(dlB._cache[].pids)
+    @test length(pidsB) == 2
+    @test isempty(intersect(pidsA, pidsB))   # disjoint: no shared workers
+    @test nprocs() == 5                      # main + 2 + 2 (grew rather than sharing)
 
-    # a loader needing more than currently exist grows the shared pool
-    dlbigger = DataLoader(D; batchsize=5, num_workers=4)
-    @test length(collect(dlbigger)) == 3
-    @test nprocs() == 5                      # grew by 1
-    @test length(dlbigger._cache[].pids) == 4
+    # each loader re-iterates on its own warm workers across epochs, no growth
+    @test length(collect(dlA)) == 3
+    @test dlA._cache[].pids == pidsA
+    @test length(collect(dlB)) == 3
+    @test dlB._cache[].pids == pidsB
+    @test nprocs() == 5
+end
+
+@testset "a dropped loader's workers return to the pool" begin
+    MLUtils.close_dataloader_pool()
+    D = reshape(collect(1.0:40.0), 4, 10)
+
+    # run a loader entirely inside a function so it is unreachable after the call returns
+    run_once() = (@test length(collect(DataLoader(D; batchsize=5, num_workers=2))) == 2; nothing)
+    run_once()
+    @test nprocs() == 3                      # main + 2
+    GC.gc(); GC.gc()                         # collect the loader; its lease is released
+
+    # a new same-size loader reuses the freed workers instead of spawning more
+    dl2 = DataLoader(D; batchsize=5, num_workers=2)
+    @test length(collect(dl2)) == 2
+    @test nprocs() == 3                      # reused, no new addprocs
 end
 
 @testset "pool teardown rebuilds a stale loader" begin


### PR DESCRIPTION
## Summary

Fixes a contention bug in distributed data loading (`num_workers`, added in #240): two `DataLoader`s that request the same `num_workers` were bound to the **same** worker processes.

The pool kept one global ordered pid vector and handed every loader the deterministic slice `pids[1:num_workers]`. So a training + validation loader (or a loader iterated inside another's loop) shared the same processes and contended:

- **Lost parallelism** — both loaders serialized onto one shared set of workers instead of each getting `num_workers`.
- **Memory blowup** — each loader's `CachingPool` cached its own `data` on the shared workers, so every worker held *both* datasets.

## Fix

Replace the shared-slice pool with **per-loader leasing** (`_lease_workers`):

- Each *live* loader leases a **disjoint** block of workers, keyed by a `WeakRef` to its per-loader `_cache`. Two loaders alive at once never share pids — the pool grows instead, matching PyTorch, where each `DataLoader` owns its workers.
- When a loader is garbage-collected, its `WeakRef` nulls and the next allocation returns its workers to the warm pool for **reuse** (not killed). A `WeakRef` vector is used rather than `WeakKeyDict` on purpose: the GC nulls a `WeakRef` synchronously, whereas `WeakKeyDict` purges only once the key's *finalizer* runs.
- Same-loader epochs still reuse the loader's own warm workers; `close_dataloader_pool()` still tears the whole pool down.

## Tests

- Rewrote the old *"multiple loaders share one pool"* test into **"concurrent loaders get disjoint workers (no contention)"** — asserts the two loaders' pids are disjoint and the pool grows rather than sharing.
- Added **"a dropped loader's workers return to the pool"** — verifies reclamation after GC.
- Kept the *reconstruct-once per worker* test working under the new semantics.

All 55 distributed tests pass (stable across repeated runs); the serial/parallel paths are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
